### PR TITLE
Change 'Checkpoint' placeholder type to 'checkpoint-item'

### DIFF
--- a/data/outcome-activity-collections/0/activities/a5.json
+++ b/data/outcome-activity-collections/0/activities/a5.json
@@ -7,7 +7,7 @@
     ],
     "properties": {
         "name": "Overall Achievement",
-        "type": "Checkpoint"
+        "type": "checkpoint-item"
     },
     "entities": [
         {

--- a/data/outcome-activity-collections/0/activities/a6.json
+++ b/data/outcome-activity-collections/0/activities/a6.json
@@ -7,7 +7,7 @@
     ],
     "properties": {
         "name": "Overall Achievement",
-        "type": "Checkpoint"
+        "type": "checkpoint-item"
     },
     "entities": [
         {

--- a/data/outcome-activity-collections/0/activities/a7.json
+++ b/data/outcome-activity-collections/0/activities/a7.json
@@ -7,7 +7,7 @@
     ],
     "properties": {
         "name": "Overall Achievement",
-        "type": "Checkpoint"
+        "type": "checkpoint-item"
     },
     "entities": [
         {

--- a/data/outcome-activity-collections/10/activities/a13.json
+++ b/data/outcome-activity-collections/10/activities/a13.json
@@ -7,7 +7,7 @@
 	],
 	"properties": {
 		"name": "Overall Achievement",
-		"type": "Checkpoint"
+		"type": "checkpoint-item"
 	},
 	"entities": [
 		{

--- a/data/outcome-activity-collections/4/activities/a3.json
+++ b/data/outcome-activity-collections/4/activities/a3.json
@@ -4,7 +4,7 @@
 	],
 	"properties": {
 		"name": "Assignment 4",
-		"type": "Checkpoint"
+		"type": "checkpoint-item"
 	},
 	"entities": [
 		{

--- a/data/outcome-activity-collections/4/activities/a6.json
+++ b/data/outcome-activity-collections/4/activities/a6.json
@@ -4,7 +4,7 @@
 	],
 	"properties": {
 		"name": "Assignment 7",
-		"type": "Checkpoint"
+		"type": "checkpoint-item"
 	},
 	"entities": [],
 	"links": [

--- a/data/outcome-activity-collections/6/activities/19.json
+++ b/data/outcome-activity-collections/6/activities/19.json
@@ -3,7 +3,7 @@
         "user-progress-outcome-activity"
     ],
     "properties": {
-        "type": "Checkpoint",
+        "type": "checkpoint-item",
         "name": "Activity 20"
     },
     "entities": [

--- a/data/outcome-activity-collections/8/activities/14.json
+++ b/data/outcome-activity-collections/8/activities/14.json
@@ -3,7 +3,7 @@
         "user-progress-outcome-activity"
     ],
     "properties": {
-        "type": "Checkpoint",
+        "type": "checkpoint-item",
         "name": "Activity 15"
     },
     "entities": [

--- a/data/outcome-activity-collections/8/activities/9.json
+++ b/data/outcome-activity-collections/8/activities/9.json
@@ -3,7 +3,7 @@
         "user-progress-outcome-activity"
     ],
     "properties": {
-        "type": "Checkpoint",
+        "type": "checkpoint-item",
         "name": "Activity 10"
     },
     "entities": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "scripts": {
     "lang:build": "lang-build -es \"\t\" -c langtools/config.json",

--- a/src/assessment-list/assessment-list.js
+++ b/src/assessment-list/assessment-list.js
@@ -8,7 +8,7 @@ import './assessment-entry';
 import './assessment-skeleton';
 
 const excludedActivityTypes = [
-	'Checkpoint'
+	'checkpoint-item'
 ];
 
 export class AssessmentList extends EntityMixinLit(LocalizeMixin(LitElement)) {

--- a/src/assessment-summary/assessment-summary.js
+++ b/src/assessment-summary/assessment-summary.js
@@ -6,7 +6,7 @@ import { OutcomeActivityCollectionEntity } from '../entities/OutcomeActivityColl
 import '../stacked-bar/stacked-bar';
 
 const excludedActivityTypes = [
-	'Checkpoint'
+	'checkpoint-item'
 ];
 
 class AssessmentSummary extends EntityMixinLit(LocalizeMixin(LitElement)) {

--- a/src/primary-panel/primary-panel.js
+++ b/src/primary-panel/primary-panel.js
@@ -96,7 +96,7 @@ class PrimaryPanel extends EntityMixinLit(LocalizeMixin(LitElement)) {
 			const outcomeActivitiesHref = entity.getOutcomeActivitiesHref();
 			entity.onOutcomeActivitiesChanged(outcomeActivities => {
 				outcomeActivities.onActivityChanged(activity => {
-					if (activity.getType() === 'Checkpoint') {
+					if (activity.getType() === 'checkpoint-item') {
 						checkpointHref = activity.getSelfHref();
 					}
 				});

--- a/src/trend/big-trend.js
+++ b/src/trend/big-trend.js
@@ -477,7 +477,7 @@ class BigTrend extends TrendMixin(LocalizeMixin(RtlMixin(LitElement))) {
 
 			let type;
 			switch (groupType.toLowerCase()) {
-				case 'checkpoint':
+				case 'checkpoint-item':
 					type = BarTypes.Diamond;
 					groupName = this.localize('labelOverallAchievement');
 					break;


### PR DESCRIPTION
In order for the `primary-panel` component to completely work with `consistent-evaluation`, the type for checkpoint item entities will need to be changed from the `Checkpoint` placeholder to `checkpoint-item`.