### PR TITLE
Add nullcheck to _getAssessedDemonstrations

### DIFF
--- a/src/entities/OutcomeActivityEntity.js
+++ b/src/entities/OutcomeActivityEntity.js
@@ -61,7 +61,7 @@ export class OutcomeActivityEntity extends Entity {
 			return;
 		}
 
-		return this._entity.getSubEntitiesByClasses([DemonstrationEntity.class, DemonstrationEntity.classes.assessed]);
+		return this._entity.entities ? this._entity.getSubEntitiesByClasses([DemonstrationEntity.class, DemonstrationEntity.classes.assessed]) : [];
 	}
 
 	_userActivityUsageHref() {


### PR DESCRIPTION
`getEntitiesByClasses` assumes that there is a subentity array for the entity. This isn't the case for checkpoint item entities. Adding a nullcheck in `_getAssessedDemonstrations` fixes this bug.