### PR TITLE
Cmitchell/cleanup local data

### DIFF
--- a/data/mastery-view-table/activities/a-unassessed-oa.json
+++ b/data/mastery-view-table/activities/a-unassessed-oa.json
@@ -9,7 +9,6 @@
         "name": "Overall Achievement",
         "type": "checkpoint-item"
     },
-    "entities": [],
     "links": [
         {
             "rel": [

--- a/data/mastery-view-table/activities/a-unassessed.json
+++ b/data/mastery-view-table/activities/a-unassessed.json
@@ -9,7 +9,6 @@
         "name": "a4",
         "type": "Dropbox"
     },
-    "entities": [],
     "links": [
         {
             "rel": [

--- a/data/mastery-view-table/class-overall-achievement/no-outcomes.json
+++ b/data/mastery-view-table/class-overall-achievement/no-outcomes.json
@@ -5,7 +5,6 @@
 	"properties": {
 		"Name": "Overall Achievement"
 	},
-	"entities": [],
 	"links": [
 		{
 			"rel": [

--- a/data/mastery-view-table/coa-classlists/0learners.json
+++ b/data/mastery-view-table/coa-classlists/0learners.json
@@ -3,7 +3,6 @@
         "collection",
         "checkpoint-user"
     ],
-    "entities": [],
     "links": [
         {
             "rel": [

--- a/data/mastery-view-table/outcome-activity-collections/class/oac-nostudents.json
+++ b/data/mastery-view-table/outcome-activity-collections/class/oac-nostudents.json
@@ -3,7 +3,6 @@
 		"collection",
 		"user-progress-outcome-activities"
 	],
-	"entities": [],
 	"links": [
 		{
 			"rel": [

--- a/data/outcome-activity-collections/4/activities/a6.json
+++ b/data/outcome-activity-collections/4/activities/a6.json
@@ -6,7 +6,6 @@
 		"name": "Assignment 7",
 		"type": "checkpoint-item"
 	},
-	"entities": [],
 	"links": [
 		{
 			"rel": [

--- a/data/outcome-activity-collections/5/activities/a1.json
+++ b/data/outcome-activity-collections/5/activities/a1.json
@@ -7,7 +7,6 @@
 		"dueDate": "2020-01-02T00:02:00.000Z",
 		"type": "Dropbox"
 	},
-	"entities": [],
 	"links": [
 		{
 			"rel": [

--- a/data/outcome-activity-collections/5/activities/a3.json
+++ b/data/outcome-activity-collections/5/activities/a3.json
@@ -7,7 +7,6 @@
 		"dueDate": "2037-12-04T00:04:00.000Z",
 		"type": "Dropbox"
 	},
-	"entities": [],
 	"links": [
 		{
 			"rel": [

--- a/data/outcome-activity-collections/7/activities/2.json
+++ b/data/outcome-activity-collections/7/activities/2.json
@@ -7,7 +7,6 @@
         "dueDate": "2020-01-03T00:00:00.000Z",
         "name": "Activity 3"
     },
-    "entities": [],
     "links": [
         {
             "rel": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.2",
+  "version": "1.1.4",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "scripts": {
     "lang:build": "lang-build -es \"\t\" -c langtools/config.json",


### PR DESCRIPTION
Follow-up to https://github.com/Brightspace/d2l-outcomes-overall-achievement/pull/19

Removes all empty subentity lists from local data to match how data will look in the LMS, and verify that all existing components are fully-functional with a null subentity list. No issues currently found in local testing.