### PR TITLE
Make token a property in primary-panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "scripts": {
     "lang:build": "lang-build -es \"\t\" -c langtools/config.json",

--- a/src/assessment-list/assessment-list.js
+++ b/src/assessment-list/assessment-list.js
@@ -87,7 +87,7 @@ export class AssessmentList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 			return html	`
 				<d2l-coa-assessment-skeleton
 					href="${this.href}"
-					token="${this.token}"
+					.token="${this.token}"
 				></d2l-coa-assessment-skeleton>
 			`;
 		}
@@ -96,7 +96,7 @@ export class AssessmentList extends EntityMixinLit(LocalizeMixin(LitElement)) {
 			<d2l-coa-assessment-entry 
 				href="${entry.demonstrationHref}" 
 				.activity="${entry.activity}" 
-				token="${this.token}">
+				.token="${this.token}">
 			</d2l-coa-assessment-entry>
 		`;
 	}

--- a/src/assessment-summary/assessment-summary.js
+++ b/src/assessment-summary/assessment-summary.js
@@ -43,7 +43,7 @@ class AssessmentSummary extends EntityMixinLit(LocalizeMixin(LitElement)) {
 			<d2l-coa-stacked-bar
 				id="chart"
 				href="${this.href}"
-				token="${this.token}"
+				.token="${this.token}"
 				excluded-types=${JSON.stringify(excludedActivityTypes)}
 			></d2l-coa-stacked-bar>
         `;

--- a/src/primary-panel/primary-panel.js
+++ b/src/primary-panel/primary-panel.js
@@ -72,7 +72,7 @@ class PrimaryPanel extends EntityMixinLit(LocalizeMixin(LitElement)) {
 			<div id="header">
 				<d2l-coa-outcome-text-display 
 					href="${this._outcomeHref}" 
-					token="${this.token}">
+					.token="${this.token}">
 				</d2l-coa-outcome-text-display>
 				${closeButton}
 			</div>
@@ -81,7 +81,7 @@ class PrimaryPanel extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
 			<d2l-coa-big-trend
 				href="${this._outcomeActivitiesHref}"
-				token="${this.token}"
+				.token="${this.token}"
 				instructor="${this.instructor}"
 				outcome-term="${this.outcomeTerm}"
 			></d2l-coa-big-trend>
@@ -90,20 +90,20 @@ class PrimaryPanel extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
 			<d2l-coa-overall-achievement-tile 
 				href="${this._checkpointHref}" 
-				token="${this.token}">
+				.token="${this.token}">
 			</d2l-coa-overall-achievement-tile>
 
 			<div class="d2l-heading-3">${this.localize('evidence')}</div>
 			<d2l-coa-assessment-summary
 				href="${this._outcomeActivitiesHref}" 
-				token="${this.token}">
+				.token="${this.token}">
 			</d2l-coa-assessment-summary>
 			
 			<div id="list-spacer"></div>
 
 			<d2l-coa-assessment-list
 				href="${this.href}"
-				token="${this.token}">
+				.token="${this.token}">
 			</d2l-coa-assessment-list>
 		`;
 	}


### PR DESCRIPTION
In consistent-eval, the token passed in `primary-panel` is a function. However, it is being parsed as a string, leading to errors during Siren requests. Making token a property fixes this issue.