### PR TITLE
Fix stacked bar total activity count

### DIFF
--- a/src/entities/OutcomeActivityCollectionEntity.js
+++ b/src/entities/OutcomeActivityCollectionEntity.js
@@ -9,8 +9,16 @@ export class OutcomeActivityCollectionEntity extends Entity {
 		};
 	}
 
+	getOutcomeActivities() {
+		if (!this._entity) {
+			return;
+		}
+
+		return this._entity.getSubEntitiesByClass(OutcomeActivityEntity.class);
+	}
+
 	onActivityChanged(onChange) {
-		const activities = this._getOutcomeActivities();
+		const activities = this.getOutcomeActivities();
 		activities.forEach((activity, index) => {
 			const onChangeWithIndex = (a) => {
 				if (a) {
@@ -33,14 +41,6 @@ export class OutcomeActivityCollectionEntity extends Entity {
 		}
 
 		return this._entity.getLinkByRel(OutcomeActivityCollectionEntity.links.defaultAchievementScale).href;
-	}
-
-	_getOutcomeActivities() {
-		if (!this._entity) {
-			return;
-		}
-
-		return this._entity.getSubEntitiesByClass(OutcomeActivityEntity.class);
 	}
 
 }

--- a/src/stacked-bar/stacked-bar.js
+++ b/src/stacked-bar/stacked-bar.js
@@ -166,7 +166,6 @@ export class StackedBar extends LocalizeMixin(EntityMixinLit(LitElement)) {
 		});
 
 		this._histData = Object.values(levelMap);
-		this._assessedCount = demonstrations.length;
 		if (this.displayUnassessed) {
 			const unassessedData = {
 				color: unassessedColor,
@@ -208,8 +207,6 @@ export class StackedBar extends LocalizeMixin(EntityMixinLit(LitElement)) {
 				if (activityType && this.excludedTypes.includes(activityType)) {
 					return;
 				}
-				this._totalCount++;
-
 				activity.onAssessedDemonstrationChanged(demonstration => {
 					const demonstratedLevel = demonstration.getDemonstratedLevel();
 					demonstrations.push(demonstratedLevel.getLevelId());
@@ -222,6 +219,8 @@ export class StackedBar extends LocalizeMixin(EntityMixinLit(LitElement)) {
 			});
 
 			entity.subEntitiesLoaded().then(() => {
+				this._assessedCount = demonstrations.length;
+				this._totalCount = entity.getOutcomeActivities().length;
 				this._buildHistData(levels, demonstrations);
 				this._skeletonLoaded = true;
 			});


### PR DESCRIPTION
In the LMS, activities within a collection were often being added multiple times to the stacked bar total activity count. This total is now obtained directly from the number of activity subentities after they are loaded, ensuring the correct value.