### PR TITLE
Properly handle outcomes with descriptions only

### DIFF
--- a/src/mastery-view-table/mastery-view-outcome-header-cell.js
+++ b/src/mastery-view-table/mastery-view-outcome-header-cell.js
@@ -161,10 +161,11 @@ export class MasteryViewOutcomeHeaderCell extends StackedBar {
 	}
 
 	render() {
+		const outcomeLabel = this.outcomeName.length > 0 ? html`${this.outcomeName}. ` : null;
 		return html`
 		<div id="cell-content-container" tabindex="0" role="button">
 			<div class="outcome-name-description">
-				<b>${this.outcomeName}.</b> ${this.outcomeDescription}
+				<b>${outcomeLabel}</b>${this.outcomeDescription}
 			</div>
 			<div id="graph-container">
 				${this._renderGraph()}
@@ -175,7 +176,7 @@ export class MasteryViewOutcomeHeaderCell extends StackedBar {
 				position="bottom"
 				align="${this.tooltipAlign}"
 			>
-				<div id="tooltip-outcome-info" aria-hidden="true">${this.outcomeName}. ${this.outcomeDescription}</div>
+				<div id="tooltip-outcome-info" aria-hidden="true">${outcomeLabel}${this.outcomeDescription}</div>
 				<table id="tooltip-level-dist-table" aria-hidden="true">
 					${this._histData.map(this._renderTooltipLine.bind(this))}
 				</table>


### PR DESCRIPTION
Fixes a minor display bug when outcomes without notation values are used in Mastery View.

**Before:**
![image](https://user-images.githubusercontent.com/6126203/96907017-a7d76e80-1468-11eb-94d3-16f50f1607e3.png)

**After:**
![image](https://user-images.githubusercontent.com/6126203/96907230-f4bb4500-1468-11eb-95a9-3875aecc723c.png)

