### PR TITLE
Fix stretched cell display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.12",
+  "version": "1.1.13",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "scripts": {
     "lang:build": "lang-build -es \"\t\" -c langtools/config.json",

--- a/src/mastery-view-table/mastery-view-outcome-header-cell.js
+++ b/src/mastery-view-table/mastery-view-outcome-header-cell.js
@@ -39,6 +39,7 @@ export class MasteryViewOutcomeHeaderCell extends StackedBar {
 					padding-top: 0.6rem;
 					padding-left: 0.6rem;
 					padding-right: 0.45rem;
+					min-height: 2rem;
 				}
 
 				:host([dir="rtl"]) .outcome-name-description {

--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -73,6 +73,11 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(LitElement)) {
 					width: 8.3rem;
 				}
 
+				.outcome-column-head {
+					vertical-align: bottom;
+					width: 9.9rem;
+				}
+
 				.learner-name-label {
 					padding: 0rem 0.8rem;
 					line-height: 3rem;
@@ -83,6 +88,10 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(LitElement)) {
 					text-decoration: underline;
 				}
 				
+				.learner-outcome-cell {
+					width: 9.9rem;
+				}
+
 				#no-learners-cell {
 					border-radius: 0;
 					border-bottom: 1px solid var(--d2l-table-border-color);
@@ -447,7 +456,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(LitElement)) {
 			</div>
 			</th>
 			${learnerData.outcomesProgressData.map(outcomeData => { return html`
-				<td role="cell">
+				<td role="cell" class="learner-outcome-cell">
 					<d2l-mastery-view-user-outcome-cell
 						href="${outcomeData.activityCollectionHref}"
 						token="${this.token}"
@@ -480,7 +489,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(LitElement)) {
 		}
 
 		return html`
-		<th scope="col">
+		<th scope="col" class="outcome-column-head">
 			<d2l-mastery-view-outcome-header-cell
 				href="${outcomeData.activityCollectionHref}"
 				token="${this.token}"

--- a/src/mastery-view-table/mastery-view-user-outcome-cell.js
+++ b/src/mastery-view-table/mastery-view-user-outcome-cell.js
@@ -30,6 +30,7 @@ export class MasteryViewUserOutcomeCell extends LocalizeMixin(EntityMixinLit(Lit
 
 			.cell-content-container {
 				width: 9.9rem;
+				height: 3rem;
 			}
 
 			#assessment-fraction-container {

--- a/src/mastery-view-table/mastery-view-user-outcome-cell.js
+++ b/src/mastery-view-table/mastery-view-user-outcome-cell.js
@@ -49,7 +49,7 @@ export class MasteryViewUserOutcomeCell extends LocalizeMixin(EntityMixinLit(Lit
 			.assessment-label-container {
 				display: inline-block;
 				padding-left: 1.5rem;
-				padding-bottom: 0.9rem;
+				padding-bottom: 0.4rem;
 			}
 
 			:host([dir="rtl"]) .assessment-label-container {


### PR DESCRIPTION
Previously, having too few columns in the Mastery View table to take up the full width of the LMS page would cause the cells to stretch. This applies the desired fixed width to each of the columns.

**Additional fixes:**
- Header cell content no longer vertically misaligned for short outcome names
- Tweaked table row height to be consistent with specs both pre- and post-loading.

**Screenshot**
![image](https://user-images.githubusercontent.com/6126203/96936811-bf2c5100-1494-11eb-8790-109f4d37c79c.png)


