### PR TITLE
Learner name truncation and flexible column width

### DIFF
--- a/data/mastery-view-table/outcome-activity-collections/class/oac-nostudents.json
+++ b/data/mastery-view-table/outcome-activity-collections/class/oac-nostudents.json
@@ -8,7 +8,7 @@
 			"rel": [
 				"self"
 			],
-			"href": "/data/mastery-view-table/outcome-activity-collections/class/oac-noneassessed.json"
+			"href": "/data/mastery-view-table/outcome-activity-collections/class/oac-nostudents.json"
 		},
 		{
 			"rel": [

--- a/data/mastery-view-table/users/u3.json
+++ b/data/mastery-view-table/users/u3.json
@@ -9,7 +9,7 @@
 				"https://api.brightspace.com/rels/first-name"
 			],
 			"properties": {
-				"name": "Hashir"
+				"name": "Exceptionally-lengthy-name-of-a"
 			}
 		},
 		{
@@ -21,7 +21,7 @@
 				"https://api.brightspace.com/rels/last-name"
 			],
 			"properties": {
-				"name": "Sargent"
+				"name": "Learner-in-the-current-class-with-some-assigned-outcomes"
 			}
 		}
 	]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.13",
+  "version": "1.1.14",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "scripts": {
     "lang:build": "lang-build -es \"\t\" -c langtools/config.json",

--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -70,7 +70,8 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
 				.learner-column-head {
 					padding: 0rem 0.8rem;
-					width: 8.3rem;
+					min-width: 9.9rem;
+					max-width: 25.6rem;
 				}
 
 				.outcome-column-head {
@@ -78,9 +79,21 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(LitElement)) {
 					width: 9.9rem;
 				}
 
+				.learner-name-cell {
+					height: 3rem;
+					max-width: 25.6rem;
+				}
+
+				.learner-name-container {
+					display: flex;
+				}
+
 				.learner-name-label {
 					padding: 0rem 0.8rem;
 					line-height: 3rem;
+					white-space: nowrap;
+					overflow: hidden;
+					text-overflow: ellipsis;
 				}
 
 				.learner-name-label:focus {
@@ -441,17 +454,20 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(LitElement)) {
 	}
 
 	_renderLearnerRow(learnerData) {
+		const userNameDisplay = this._getUserNameDisplay(learnerData.firstName, learnerData.lastName, this._nameFirstLastFormat);
+
 		return html`
 		<tr>
 			<th scope="row" sticky class="learner-name-cell">
-			<div class="learner-name">
+			<div class="learner-name-container">
 				<a
 					href="${learnerData.gradesPageHref}"
 					class="d2l-link learner-name-label"
 					role="region"
 					aria-label=${this.localize('goToUserAchievementSummaryPage', 'username', learnerData.firstName + ' ' + learnerData.lastName)}
+					title=${userNameDisplay}
 				>
-					${this._getUserNameDisplay(learnerData.firstName, learnerData.lastName, this._nameFirstLastFormat)}
+					${userNameDisplay}
 				</a>
 			</div>
 			</th>


### PR DESCRIPTION
To prevent learner row height inconsistencies and related display issues, learner names are now clamped to a single line. The learner column now has a set min and max width; if a learner's name exceeds this width it will be truncated with ellipses. In this case, a hover-over label allows the full name to be viewed. 

![image](https://user-images.githubusercontent.com/6126203/97051110-9d8ea080-154c-11eb-91fb-422c8e7b76ff.png)
