### PR TITLE
DE41081 - Refresh activities upon updating evaluation

### DIFF
--- a/src/overall-achievement-tile/overall-achievement-tile.js
+++ b/src/overall-achievement-tile/overall-achievement-tile.js
@@ -195,10 +195,6 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 		}
 	}
 
-	_refreshEntity() {
-		window.D2L.Siren.EntityStore.fetch(this.href, this.token, true);
-	}
-
 	_onEntityChanged(entity) {
 		if (entity) {
 			let levelName, levelColor, accessDate, feedback, published;
@@ -225,6 +221,10 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 				this._published = published;
 			});
 		}
+	}
+
+	_refreshEntity() {
+		window.D2L.Siren.EntityStore.fetch(this.href, this.token, true);
 	}
 
 	_renderFeedback(feedbackData) {

--- a/src/overall-achievement-tile/overall-achievement-tile.js
+++ b/src/overall-achievement-tile/overall-achievement-tile.js
@@ -143,6 +143,17 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 		this._activityName = '';
 		this._levelColor = '';
 		this._levelName = '';
+		this.refreshEntity = this._refreshEntity.bind(this);
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		window.addEventListener('d2l-save-evaluation', this.refreshEntity);
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		window.removeEventListener('d2l-save-evaluation', this.refreshEntity);
 	}
 
 	render() {
@@ -182,6 +193,10 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 			this._onEntityChanged(entity);
 			super._entity = entity;
 		}
+	}
+
+	_refreshEntity() {
+		window.D2L.Siren.EntityStore.fetch(this.href, this.token, true);
 	}
 
 	_onEntityChanged(entity) {

--- a/src/primary-panel/primary-panel.js
+++ b/src/primary-panel/primary-panel.js
@@ -62,14 +62,24 @@ class PrimaryPanel extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
 		this.instructor = false;
 		this.showClose = false;
+		this.refreshEntity = this._refreshEntity.bind(this);
 		this._outcomeHref = '';
 		this._outcomeActivitiesHref = '';
 		this._checkpointHref = '';
 	}
 
-	refreshOverallAchievementActivities() {
-		this.shadowRoot.querySelector('d2l-coa-big-trend')._getEntity();
-		this.shadowRoot.querySelector('d2l-coa-overall-achievement-tile')._getEntity();
+	connectedCallback() {
+		super.connectedCallback();
+		window.addEventListener('d2l-save-evaluation', this.refreshEntity);
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		window.removeEventListener('d2l-save-evaluation', this.refreshEntity);
+	}
+
+	_refreshEntity() {
+		//window.D2L.Siren.EntityStore.fetch(this.href, this.token, true);
 	}
 
 	render() {

--- a/src/primary-panel/primary-panel.js
+++ b/src/primary-panel/primary-panel.js
@@ -78,10 +78,6 @@ class PrimaryPanel extends EntityMixinLit(LocalizeMixin(LitElement)) {
 		window.removeEventListener('d2l-save-evaluation', this.refreshEntity);
 	}
 
-	_refreshEntity() {
-		//window.D2L.Siren.EntityStore.fetch(this.href, this.token, true);
-	}
-
 	render() {
 		const closeButton = this.showClose ? html`
 			<d2l-button-icon
@@ -171,6 +167,9 @@ class PrimaryPanel extends EntityMixinLit(LocalizeMixin(LitElement)) {
 		}
 	}
 
+	_refreshEntity() {
+		window.D2L.Siren.EntityStore.fetch(this.href, this.token, true);
+	}
 }
 
 customElements.define(PrimaryPanel.is, PrimaryPanel);

--- a/src/primary-panel/primary-panel.js
+++ b/src/primary-panel/primary-panel.js
@@ -67,6 +67,11 @@ class PrimaryPanel extends EntityMixinLit(LocalizeMixin(LitElement)) {
 		this._checkpointHref = '';
 	}
 
+	refreshOverallAchievementActivities() {
+		this.shadowRoot.querySelector('d2l-coa-big-trend')._getEntity();
+		this.shadowRoot.querySelector('d2l-coa-overall-achievement-tile')._getEntity();
+	}
+
 	render() {
 		const closeButton = this.showClose
 			? html`<d2l-button-icon class="close-button" icon="d2l-tier1:close-large-thick" text="${this.localize('close')}" @click=${this._close}></d2l-button-icon>`

--- a/src/trend/big-trend.js
+++ b/src/trend/big-trend.js
@@ -731,7 +731,8 @@ class BigTrend extends TrendMixin(LocalizeMixin(RtlMixin(LitElement))) {
 				const postStyles = [
 					`height:${block.height + extraPoleHeight - DIAMOND_WIDTH + diamondOverflow}px`,
 					`background-color:${block.color}`,
-					`top:${GRID_THICKNESS + sizeDiff - extraPoleHeight - diamondOverflow}px`
+					`top:${GRID_THICKNESS + sizeDiff - extraPoleHeight - diamondOverflow}px`,
+					`transition: height 0.3s ease-out`
 				].join(';');
 
 				return html`

--- a/src/trend/big-trend.js
+++ b/src/trend/big-trend.js
@@ -732,7 +732,7 @@ class BigTrend extends TrendMixin(LocalizeMixin(RtlMixin(LitElement))) {
 					`height:${block.height + extraPoleHeight - DIAMOND_WIDTH + diamondOverflow}px`,
 					`background-color:${block.color}`,
 					`top:${GRID_THICKNESS + sizeDiff - extraPoleHeight - diamondOverflow}px`,
-					`transition: height 0.3s ease-out`
+					'transition: height 0.3s ease-out'
 				].join(';');
 
 				return html`

--- a/src/trend/big-trend.js
+++ b/src/trend/big-trend.js
@@ -279,6 +279,17 @@ class BigTrend extends TrendMixin(LocalizeMixin(RtlMixin(LitElement))) {
 	constructor() {
 		super();
 		this.instructor = false;
+		this.refreshEntity = this._refreshEntity.bind(this);
+	}
+
+	connectedCallback() {
+		super.connectedCallback();
+		window.addEventListener('d2l-save-evaluation', this.refreshEntity);
+	}
+
+	disconnectedCallback() {
+		super.disconnectedCallback();
+		window.removeEventListener('d2l-save-evaluation', this.refreshEntity);
 	}
 
 	firstUpdated() {
@@ -619,6 +630,10 @@ class BigTrend extends TrendMixin(LocalizeMixin(RtlMixin(LitElement))) {
 		}
 
 		this.scrollContainer.scrollLeft += scrollAmount;
+	}
+
+	_refreshEntity() {
+		window.D2L.Siren.EntityStore.fetch(this.href, this.token, true);
 	}
 
 	_renderScreenReaderText(trendItems) {


### PR DESCRIPTION
Add a function to refresh outcome activities which can be called by consistent-evaluation whenever an evaluation is saved/published/updated