### PR TITLE
Add demonstratedLevel nullcheck for Checkpoint Demonstrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "scripts": {
     "lang:build": "lang-build -es \"\t\" -c langtools/config.json",

--- a/src/mastery-view-table/mastery-view-user-outcome-cell.js
+++ b/src/mastery-view-table/mastery-view-user-outcome-cell.js
@@ -244,11 +244,13 @@ export class MasteryViewUserOutcomeCell extends LocalizeMixin(EntityMixinLit(Lit
 			isPublished = demonstration.isPublished();
 
 			const demonstratedLevel = demonstration.getDemonstratedLevel();
-			hasManualOverride = demonstratedLevel.isManualOverride();
-			demonstratedLevel.onLevelChanged(loa => {
-				name = loa.getName();
-				color = loa.getColor();
-			});
+			if (demonstratedLevel) {
+				hasManualOverride = demonstratedLevel.isManualOverride();
+				demonstratedLevel.onLevelChanged(loa => {
+					name = loa.getName();
+					color = loa.getColor();
+				});
+			}
 		});
 
 		entity.subEntitiesLoaded().then(() => {


### PR DESCRIPTION
Don't know if anybody else has the same issue, but it seems that table cell rendering fails when a checkpoint item demonstration does not have a demonstrated level. Adding a nullcheck fixes this.