### PR TITLE
DE41109: mv distribution bar calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.18",
+  "version": "1.1.19",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "scripts": {
     "lang:build": "lang-build -es \"\t\" -c langtools/config.json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.19",
+  "version": "1.1.20",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "scripts": {
     "lang:build": "lang-build -es \"\t\" -c langtools/config.json",

--- a/src/stacked-bar/stacked-bar.js
+++ b/src/stacked-bar/stacked-bar.js
@@ -207,9 +207,16 @@ export class StackedBar extends LocalizeMixin(EntityMixinLit(LitElement)) {
 				if (activityType && this.excludedTypes.includes(activityType)) {
 					return;
 				}
+				let levelId;
 				activity.onAssessedDemonstrationChanged(demonstration => {
 					const demonstratedLevel = demonstration.getDemonstratedLevel();
-					demonstrations.push(demonstratedLevel.getLevelId());
+					levelId = demonstratedLevel.getLevelId();
+				});
+
+				activity.subEntitiesLoaded().then(() => {
+					if (levelId) {
+						demonstrations.push(levelId);
+					}
 				});
 			});
 


### PR DESCRIPTION
Inconsistent appearance was due to demonstrated levels sometimes being counted multiple times (depending on number of onAssessedDemonstrationChanged calls for an activity). Waiting for subEntitiesLoaded() for the activity before counting its demonstration avoids this problem.