### PR TITLE
Stacked Bar: Handle Multi-Demonstration Activities

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.23",
+  "version": "1.1.24",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "scripts": {
     "lang:build": "lang-build -es \"\t\" -c langtools/config.json",

--- a/src/stacked-bar/stacked-bar.js
+++ b/src/stacked-bar/stacked-bar.js
@@ -178,11 +178,12 @@ export class StackedBar extends SkeletonMixin(LocalizeMixin(EntityMixinLit(LitEl
 			};
 			return acc;
 		}, {});
-		demonstrations.forEach(demonstratedLevel => {
+		for (const href in demonstrations) {
+			const demonstratedLevel = demonstrations[href];
 			if (levelMap[demonstratedLevel]) {
 				levelMap[demonstratedLevel].count++;
 			}
-		});
+		}
 
 		this._histData = Object.values(levelMap);
 		if (this.displayUnassessed) {
@@ -220,21 +221,18 @@ export class StackedBar extends SkeletonMixin(LocalizeMixin(EntityMixinLit(LitEl
 
 	_onEntityChanged(entity) {
 		if (entity) {
-			const demonstrations = [];
+			const demonstrations = {};
 			entity.onActivityChanged(activity => {
 				const activityType = activity.getType();
 				if (activityType && this.excludedTypes.includes(activityType)) {
 					return;
 				}
-				let levelId;
 				activity.onAssessedDemonstrationChanged(demonstration => {
+					const demonstrationHref = demonstration.getSelfHref();
 					const demonstratedLevel = demonstration.getDemonstratedLevel();
-					levelId = demonstratedLevel.getLevelId();
-				});
-
-				activity.subEntitiesLoaded().then(() => {
-					if (levelId) {
-						demonstrations.push(levelId);
+					const levelId = demonstratedLevel.getLevelId();
+					if (levelId && demonstrationHref) {
+						demonstrations[demonstrationHref] = levelId;
 					}
 				});
 			});
@@ -245,7 +243,7 @@ export class StackedBar extends SkeletonMixin(LocalizeMixin(EntityMixinLit(LitEl
 			});
 
 			entity.subEntitiesLoaded().then(() => {
-				this._assessedCount = demonstrations.length;
+				this._assessedCount = Object.keys(demonstrations).length;
 				this._totalCount = entity.getOutcomeActivities().length;
 				this._buildHistData(levels, demonstrations);
 				this.skeleton = false;


### PR DESCRIPTION
Stacked bar now adds demonstrations' level IDs to an href-based dictionary. This achieves two things:

1. For activities with multiple demonstrations (such as multi-attempt quizzes), all will be counted and shown in the assessment summary
2. Each demonstration is only included once in the histogram data, preventing skewed display issues seen in a previously fixed MV header defect