### PR TITLE
Fix visual bug with MV header cell

### DIFF
--- a/src/mastery-view-table/mastery-view-outcome-header-cell.js
+++ b/src/mastery-view-table/mastery-view-outcome-header-cell.js
@@ -31,6 +31,10 @@ export class MasteryViewOutcomeHeaderCell extends StackedBar {
 					outline-color: var(--d2l-color-celestine);
 				}
 
+				#cell-content-container {
+					width: 9.9rem;
+				}
+
 				.outcome-name-description {
 					overflow: hidden;
 					text-overflow: ellipsis;


### PR DESCRIPTION
If outcome name had very long un-broken word, cell width would be
increased