### PR TITLE
FIx panel update after removing overall achievement level

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.24",
+  "version": "1.1.25",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "scripts": {
     "lang:build": "lang-build -es \"\t\" -c langtools/config.json",

--- a/src/overall-achievement-tile/overall-achievement-tile.js
+++ b/src/overall-achievement-tile/overall-achievement-tile.js
@@ -199,14 +199,14 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 		if (entity) {
 			let levelName, levelColor, accessDate, feedback, published;
 			entity.onAssessedDemonstrationChanged(demonstration => {
-				if(!demonstration) {
+				if (!demonstration) {
 					return;
 				}
 				demonstration.onFeedbackChanged(feedbackList => {
 					feedback = feedbackList.getFeedback();
 				});
 				const demonstratedLevel = demonstration.getDemonstratedLevel();
-				if(!demonstratedLevel) {
+				if (!demonstratedLevel) {
 					return;
 				}
 				demonstratedLevel.onLevelChanged(level => {

--- a/src/overall-achievement-tile/overall-achievement-tile.js
+++ b/src/overall-achievement-tile/overall-achievement-tile.js
@@ -199,10 +199,16 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 		if (entity) {
 			let levelName, levelColor, accessDate, feedback, published;
 			entity.onAssessedDemonstrationChanged(demonstration => {
+				if(!demonstration) {
+					return;
+				}
 				demonstration.onFeedbackChanged(feedbackList => {
 					feedback = feedbackList.getFeedback();
 				});
 				const demonstratedLevel = demonstration.getDemonstratedLevel();
+				if(!demonstratedLevel) {
+					return;
+				}
 				demonstratedLevel.onLevelChanged(level => {
 					levelName = level.getName();
 					levelColor = level.getColor();

--- a/src/primary-panel/primary-panel.js
+++ b/src/primary-panel/primary-panel.js
@@ -152,7 +152,13 @@ class PrimaryPanel extends EntityMixinLit(LocalizeMixin(LitElement)) {
 			const outcomeHref = entity.getOutcomeHref();
 			const outcomeActivitiesHref = entity.getOutcomeActivitiesHref();
 			entity.onOutcomeActivitiesChanged(outcomeActivities => {
+				if(!outcomeActivities) {
+					return;
+				}
 				outcomeActivities.onActivityChanged(activity => {
+					if(!activity) {
+						return;
+					}
 					if (activity.getType() === 'checkpoint-item') {
 						checkpointHref = activity.getSelfHref();
 					}

--- a/src/primary-panel/primary-panel.js
+++ b/src/primary-panel/primary-panel.js
@@ -152,11 +152,11 @@ class PrimaryPanel extends EntityMixinLit(LocalizeMixin(LitElement)) {
 			const outcomeHref = entity.getOutcomeHref();
 			const outcomeActivitiesHref = entity.getOutcomeActivitiesHref();
 			entity.onOutcomeActivitiesChanged(outcomeActivities => {
-				if(!outcomeActivities) {
+				if (!outcomeActivities) {
 					return;
 				}
 				outcomeActivities.onActivityChanged(activity => {
-					if(!activity) {
+					if (!activity) {
 						return;
 					}
 					if (activity.getType() === 'checkpoint-item') {

--- a/src/trend/TrendMixin.js
+++ b/src/trend/TrendMixin.js
@@ -36,8 +36,14 @@ export const TrendMixin = (superclass) => class extends EntityMixinLit(superclas
 				};
 
 				activity.onAssessedDemonstrationChanged(demonstration => {
+					if(!demonstration) {
+						return;
+					}
 					const assessedDate = demonstration.getDateAssessed();
 					const demonstratedLevel = demonstration.getDemonstratedLevel();
+					if(!demonstratedLevel) {
+						return;
+					}
 					const levelId = demonstratedLevel.getLevelId();
 
 					const attempt = {

--- a/src/trend/TrendMixin.js
+++ b/src/trend/TrendMixin.js
@@ -36,12 +36,12 @@ export const TrendMixin = (superclass) => class extends EntityMixinLit(superclas
 				};
 
 				activity.onAssessedDemonstrationChanged(demonstration => {
-					if(!demonstration) {
+					if (!demonstration) {
 						return;
 					}
 					const assessedDate = demonstration.getDateAssessed();
 					const demonstratedLevel = demonstration.getDemonstratedLevel();
-					if(!demonstratedLevel) {
+					if (!demonstratedLevel) {
 						return;
 					}
 					const levelId = demonstratedLevel.getLevelId();


### PR DESCRIPTION
Adds null checks so that when an overall assessment override to no have no selected LOA is saved, the primary panel will update, and do so without throwing errors.