### PR TITLE
Add position to container of graph-container

### DIFF
--- a/src/stacked-bar/stacked-bar.js
+++ b/src/stacked-bar/stacked-bar.js
@@ -26,6 +26,10 @@ export class StackedBar extends SkeletonMixin(LocalizeMixin(EntityMixinLit(LitEl
 		return [
 			super.styles,
 			css`
+				#container {
+					position: relative;
+				}
+
 				#graph-container {
 					align-items: stretch;
 					display: flex;


### PR DESCRIPTION
Add a `position: relative` to the container of `graph-container` of the stacked bar so that the tooltip does not end up at the wrong place in User Progress when scrolling down
https://rally1.rallydev.com/#/detail/defect/454988934124?fdp=true
