### PR TITLE
Fix MV accessibility + override logic

### DIFF
--- a/build/lang/ar.js
+++ b/build/lang/ar.js
@@ -9,7 +9,7 @@ export const val = {
 	'firstName': 'First name',
 	'goToNextPage': 'Go to the next page in the table.',
 	'goToPreviousPage': 'Go to the previous page in the table.',
-	'goToUserAchievementSummaryPage': 'Press space or enter to open users achievement summary page.',
+	'goToUserAchievementSummaryPage': 'Press space or enter to open {name}\'s achievement summary page.',
 	'headingDate': 'Date',
 	'headingEvidence': 'Evidence Name',
 	'headingLoa': 'Level of Achievement',

--- a/build/lang/de.js
+++ b/build/lang/de.js
@@ -9,7 +9,7 @@ export const val = {
 	'firstName': 'First name',
 	'goToNextPage': 'Go to the next page in the table.',
 	'goToPreviousPage': 'Go to the previous page in the table.',
-	'goToUserAchievementSummaryPage': 'Press space or enter to open users achievement summary page.',
+	'goToUserAchievementSummaryPage': 'Press space or enter to open {name}\'s achievement summary page.',
 	'headingDate': 'Date',
 	'headingEvidence': 'Evidence Name',
 	'headingLoa': 'Level of Achievement',

--- a/build/lang/en.js
+++ b/build/lang/en.js
@@ -9,7 +9,7 @@ export const val = {
 	'firstName': 'First name',
 	'goToNextPage': 'Go to the next page in the table.',
 	'goToPreviousPage': 'Go to the previous page in the table.',
-	'goToUserAchievementSummaryPage': 'Press space or enter to open users achievement summary page.',
+	'goToUserAchievementSummaryPage': 'Press space or enter to open {name}\'s achievement summary page.',
 	'headingDate': 'Date',
 	'headingEvidence': 'Evidence Name',
 	'headingLoa': 'Level of Achievement',

--- a/build/lang/es.js
+++ b/build/lang/es.js
@@ -9,7 +9,7 @@ export const val = {
 	'firstName': 'First name',
 	'goToNextPage': 'Go to the next page in the table.',
 	'goToPreviousPage': 'Go to the previous page in the table.',
-	'goToUserAchievementSummaryPage': 'Press space or enter to open users achievement summary page.',
+	'goToUserAchievementSummaryPage': 'Press space or enter to open {name}\'s achievement summary page.',
 	'headingDate': 'Date',
 	'headingEvidence': 'Evidence Name',
 	'headingLoa': 'Level of Achievement',

--- a/build/lang/fr.js
+++ b/build/lang/fr.js
@@ -9,7 +9,7 @@ export const val = {
 	'firstName': 'First name',
 	'goToNextPage': 'Go to the next page in the table.',
 	'goToPreviousPage': 'Go to the previous page in the table.',
-	'goToUserAchievementSummaryPage': 'Press space or enter to open users achievement summary page.',
+	'goToUserAchievementSummaryPage': 'Press space or enter to open {name}\'s achievement summary page.',
 	'headingDate': 'Date',
 	'headingEvidence': 'Evidence Name',
 	'headingLoa': 'Level of Achievement',

--- a/build/lang/ja.js
+++ b/build/lang/ja.js
@@ -9,7 +9,7 @@ export const val = {
 	'firstName': 'First name',
 	'goToNextPage': 'Go to the next page in the table.',
 	'goToPreviousPage': 'Go to the previous page in the table.',
-	'goToUserAchievementSummaryPage': 'Press space or enter to open users achievement summary page.',
+	'goToUserAchievementSummaryPage': 'Press space or enter to open {name}\'s achievement summary page.',
 	'headingDate': 'Date',
 	'headingEvidence': 'Evidence Name',
 	'headingLoa': 'Level of Achievement',

--- a/build/lang/ko.js
+++ b/build/lang/ko.js
@@ -9,7 +9,7 @@ export const val = {
 	'firstName': 'First name',
 	'goToNextPage': 'Go to the next page in the table.',
 	'goToPreviousPage': 'Go to the previous page in the table.',
-	'goToUserAchievementSummaryPage': 'Press space or enter to open users achievement summary page.',
+	'goToUserAchievementSummaryPage': 'Press space or enter to open {name}\'s achievement summary page.',
 	'headingDate': 'Date',
 	'headingEvidence': 'Evidence Name',
 	'headingLoa': 'Level of Achievement',

--- a/build/lang/nl.js
+++ b/build/lang/nl.js
@@ -9,7 +9,7 @@ export const val = {
 	'firstName': 'First name',
 	'goToNextPage': 'Go to the next page in the table.',
 	'goToPreviousPage': 'Go to the previous page in the table.',
-	'goToUserAchievementSummaryPage': 'Press space or enter to open users achievement summary page.',
+	'goToUserAchievementSummaryPage': 'Press space or enter to open {name}\'s achievement summary page.',
 	'headingDate': 'Date',
 	'headingEvidence': 'Evidence Name',
 	'headingLoa': 'Level of Achievement',

--- a/build/lang/pt.js
+++ b/build/lang/pt.js
@@ -9,7 +9,7 @@ export const val = {
 	'firstName': 'First name',
 	'goToNextPage': 'Go to the next page in the table.',
 	'goToPreviousPage': 'Go to the previous page in the table.',
-	'goToUserAchievementSummaryPage': 'Press space or enter to open users achievement summary page.',
+	'goToUserAchievementSummaryPage': 'Press space or enter to open {name}\'s achievement summary page.',
 	'headingDate': 'Date',
 	'headingEvidence': 'Evidence Name',
 	'headingLoa': 'Level of Achievement',

--- a/build/lang/sv.js
+++ b/build/lang/sv.js
@@ -9,7 +9,7 @@ export const val = {
 	'firstName': 'First name',
 	'goToNextPage': 'Go to the next page in the table.',
 	'goToPreviousPage': 'Go to the previous page in the table.',
-	'goToUserAchievementSummaryPage': 'Press space or enter to open users achievement summary page.',
+	'goToUserAchievementSummaryPage': 'Press space or enter to open {name}\'s achievement summary page.',
 	'headingDate': 'Date',
 	'headingEvidence': 'Evidence Name',
 	'headingLoa': 'Level of Achievement',

--- a/build/lang/tr.js
+++ b/build/lang/tr.js
@@ -9,7 +9,7 @@ export const val = {
 	'firstName': 'First name',
 	'goToNextPage': 'Go to the next page in the table.',
 	'goToPreviousPage': 'Go to the previous page in the table.',
-	'goToUserAchievementSummaryPage': 'Press space or enter to open users achievement summary page.',
+	'goToUserAchievementSummaryPage': 'Press space or enter to open {name}\'s achievement summary page.',
 	'headingDate': 'Date',
 	'headingEvidence': 'Evidence Name',
 	'headingLoa': 'Level of Achievement',

--- a/build/lang/zh-tw.js
+++ b/build/lang/zh-tw.js
@@ -9,7 +9,7 @@ export const val = {
 	'firstName': 'First name',
 	'goToNextPage': 'Go to the next page in the table.',
 	'goToPreviousPage': 'Go to the previous page in the table.',
-	'goToUserAchievementSummaryPage': 'Press space or enter to open users achievement summary page.',
+	'goToUserAchievementSummaryPage': 'Press space or enter to open {name}\'s achievement summary page.',
 	'headingDate': 'Date',
 	'headingEvidence': 'Evidence Name',
 	'headingLoa': 'Level of Achievement',

--- a/build/lang/zh.js
+++ b/build/lang/zh.js
@@ -9,7 +9,7 @@ export const val = {
 	'firstName': 'First name',
 	'goToNextPage': 'Go to the next page in the table.',
 	'goToPreviousPage': 'Go to the previous page in the table.',
-	'goToUserAchievementSummaryPage': 'Press space or enter to open users achievement summary page.',
+	'goToUserAchievementSummaryPage': 'Press space or enter to open {name}\'s achievement summary page.',
 	'headingDate': 'Date',
 	'headingEvidence': 'Evidence Name',
 	'headingLoa': 'Level of Achievement',

--- a/lang/ar.json
+++ b/lang/ar.json
@@ -9,7 +9,7 @@
     "firstName": "First name",
     "goToNextPage": "Go to the next page in the table.",
     "goToPreviousPage": "Go to the previous page in the table.",
-    "goToUserAchievementSummaryPage": "Press space or enter to open users achievement summary page.",
+    "goToUserAchievementSummaryPage": "Press space or enter to open {name}'s achievement summary page.",
     "headingDate": "Date",
     "headingEvidence": "Evidence Name",
     "headingLoa": "Level of Achievement",

--- a/lang/de.json
+++ b/lang/de.json
@@ -9,7 +9,7 @@
     "firstName": "First name",
     "goToNextPage": "Go to the next page in the table.",
     "goToPreviousPage": "Go to the previous page in the table.",
-    "goToUserAchievementSummaryPage": "Press space or enter to open users achievement summary page.",
+    "goToUserAchievementSummaryPage": "Press space or enter to open {name}'s achievement summary page.",
     "headingDate": "Date",
     "headingEvidence": "Evidence Name",
     "headingLoa": "Level of Achievement",

--- a/lang/en.json
+++ b/lang/en.json
@@ -9,7 +9,7 @@
     "firstName": "First name",
     "goToNextPage": "Go to the next page in the table.",
     "goToPreviousPage": "Go to the previous page in the table.",
-    "goToUserAchievementSummaryPage": "Press space or enter to open users achievement summary page.",
+    "goToUserAchievementSummaryPage": "Press space or enter to open {name}'s achievement summary page.",
     "headingDate": "Date",
     "headingEvidence": "Evidence Name",
     "headingLoa": "Level of Achievement",

--- a/lang/es.json
+++ b/lang/es.json
@@ -9,7 +9,7 @@
     "firstName": "First name",
     "goToNextPage": "Go to the next page in the table.",
     "goToPreviousPage": "Go to the previous page in the table.",
-    "goToUserAchievementSummaryPage": "Press space or enter to open users achievement summary page.",
+    "goToUserAchievementSummaryPage": "Press space or enter to open {name}'s achievement summary page.",
     "headingDate": "Date",
     "headingEvidence": "Evidence Name",
     "headingLoa": "Level of Achievement",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -9,7 +9,7 @@
     "firstName": "First name",
     "goToNextPage": "Go to the next page in the table.",
     "goToPreviousPage": "Go to the previous page in the table.",
-    "goToUserAchievementSummaryPage": "Press space or enter to open users achievement summary page.",
+    "goToUserAchievementSummaryPage": "Press space or enter to open {name}'s achievement summary page.",
     "headingDate": "Date",
     "headingEvidence": "Evidence Name",
     "headingLoa": "Level of Achievement",

--- a/lang/ja.json
+++ b/lang/ja.json
@@ -9,7 +9,7 @@
     "firstName": "First name",
     "goToNextPage": "Go to the next page in the table.",
     "goToPreviousPage": "Go to the previous page in the table.",
-    "goToUserAchievementSummaryPage": "Press space or enter to open users achievement summary page.",
+    "goToUserAchievementSummaryPage": "Press space or enter to open {name}'s achievement summary page.",
     "headingDate": "Date",
     "headingEvidence": "Evidence Name",
     "headingLoa": "Level of Achievement",

--- a/lang/ko.json
+++ b/lang/ko.json
@@ -9,7 +9,7 @@
     "firstName": "First name",
     "goToNextPage": "Go to the next page in the table.",
     "goToPreviousPage": "Go to the previous page in the table.",
-    "goToUserAchievementSummaryPage": "Press space or enter to open users achievement summary page.",
+    "goToUserAchievementSummaryPage": "Press space or enter to open {name}'s achievement summary page.",
     "headingDate": "Date",
     "headingEvidence": "Evidence Name",
     "headingLoa": "Level of Achievement",

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -9,7 +9,7 @@
     "firstName": "First name",
     "goToNextPage": "Go to the next page in the table.",
     "goToPreviousPage": "Go to the previous page in the table.",
-    "goToUserAchievementSummaryPage": "Press space or enter to open users achievement summary page.",
+    "goToUserAchievementSummaryPage": "Press space or enter to open {name}'s achievement summary page.",
     "headingDate": "Date",
     "headingEvidence": "Evidence Name",
     "headingLoa": "Level of Achievement",

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -9,7 +9,7 @@
     "firstName": "First name",
     "goToNextPage": "Go to the next page in the table.",
     "goToPreviousPage": "Go to the previous page in the table.",
-    "goToUserAchievementSummaryPage": "Press space or enter to open users achievement summary page.",
+    "goToUserAchievementSummaryPage": "Press space or enter to open {name}'s achievement summary page.",
     "headingDate": "Date",
     "headingEvidence": "Evidence Name",
     "headingLoa": "Level of Achievement",

--- a/lang/sv.json
+++ b/lang/sv.json
@@ -9,7 +9,7 @@
     "firstName": "First name",
     "goToNextPage": "Go to the next page in the table.",
     "goToPreviousPage": "Go to the previous page in the table.",
-    "goToUserAchievementSummaryPage": "Press space or enter to open users achievement summary page.",
+    "goToUserAchievementSummaryPage": "Press space or enter to open {name}'s achievement summary page.",
     "headingDate": "Date",
     "headingEvidence": "Evidence Name",
     "headingLoa": "Level of Achievement",

--- a/lang/tr.json
+++ b/lang/tr.json
@@ -9,7 +9,7 @@
     "firstName": "First name",
     "goToNextPage": "Go to the next page in the table.",
     "goToPreviousPage": "Go to the previous page in the table.",
-    "goToUserAchievementSummaryPage": "Press space or enter to open users achievement summary page.",
+    "goToUserAchievementSummaryPage": "Press space or enter to open {name}'s achievement summary page.",
     "headingDate": "Date",
     "headingEvidence": "Evidence Name",
     "headingLoa": "Level of Achievement",

--- a/lang/zh-tw.json
+++ b/lang/zh-tw.json
@@ -9,7 +9,7 @@
     "firstName": "First name",
     "goToNextPage": "Go to the next page in the table.",
     "goToPreviousPage": "Go to the previous page in the table.",
-    "goToUserAchievementSummaryPage": "Press space or enter to open users achievement summary page.",
+    "goToUserAchievementSummaryPage": "Press space or enter to open {name}'s achievement summary page.",
     "headingDate": "Date",
     "headingEvidence": "Evidence Name",
     "headingLoa": "Level of Achievement",

--- a/lang/zh.json
+++ b/lang/zh.json
@@ -9,7 +9,7 @@
     "firstName": "First name",
     "goToNextPage": "Go to the next page in the table.",
     "goToPreviousPage": "Go to the previous page in the table.",
-    "goToUserAchievementSummaryPage": "Press space or enter to open users achievement summary page.",
+    "goToUserAchievementSummaryPage": "Press space or enter to open {name}'s achievement summary page.",
     "headingDate": "Date",
     "headingEvidence": "Evidence Name",
     "headingLoa": "Level of Achievement",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "scripts": {
     "lang:build": "lang-build -es \"\t\" -c langtools/config.json",

--- a/src/consts.js
+++ b/src/consts.js
@@ -1,5 +1,8 @@
 export const Consts = {
 	events: {
 		primaryPanelCloseClicked: 'd2l-coa-primary-panel-closed'
-	}
+	},
+	noCoaLevelName: '-',
+	noCoaLevelColor: '#FFFFFF',
+	tenPercentAlphaHex: '1A',
 };

--- a/src/entities/DemonstrationEntity.js
+++ b/src/entities/DemonstrationEntity.js
@@ -22,6 +22,14 @@ export class DemonstrationEntity extends Entity {
 		};
 	}
 
+	getAllDemonstratableLevels() {
+		if (!this._entity) {
+			return;
+		}
+		const levels = this._entity.getSubEntitiesByClass(DemonstratableLevelEntity.class);
+		return levels.map(level => new DemonstratableLevelEntity(this, level));
+	}
+
 	getDateAssessed() {
 		return this._entity && this._entity.properties && this._entity.properties.dateAssessed;
 	}
@@ -99,10 +107,6 @@ export class DemonstratableLevelEntity extends SelflessEntity {
 
 	getLevelId() {
 		return this._entity && this._entity.properties && this._entity.properties.levelId;
-	}
-
-	isManualOverride() {
-		return this.isSelected() && !this.isSuggested();
 	}
 
 	isSelected() {

--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -379,7 +379,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(LitElement)) {
 			displayText = lastName + ', ' + firstName;
 		}
 
-		if(firstName && lastName) {
+		if (firstName && lastName) {
 			ariaText = firstName + ' ' + lastName;
 		}
 		else {

--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -345,26 +345,52 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(LitElement)) {
 		);
 	}
 
-	_getUserNameDisplay(firstName, lastName) {
-		let displayString;
-
+	_getUserAriaName(firstName, lastName) {
 		if (!firstName && !lastName) {
-			displayString = this.localize('anonymousUser');
+			return this.localize('anonymousUser');
 		}
 		else if (!firstName) {
-			displayString = lastName;
+			return lastName;
 		}
 		else if (!lastName) {
-			displayString = firstName;
-		}
-		else if (this._nameFirstLastFormat) {
-			return firstName + ' ' + lastName;
+			return firstName;
 		}
 		else {
-			return lastName + ', ' + firstName;
+			return firstName + ' ' + lastName;
+		}
+	}
+
+	_getUserNameText(firstName, lastName, firstLastDisplay) {
+		let displayText, ariaText;
+
+		if (!firstName && !lastName) {
+			displayText = this.localize('anonymousUser');
+		}
+		else if (!firstName) {
+			displayText = lastName;
+		}
+		else if (!lastName) {
+			displayText = firstName;
+		}
+		else if (firstLastDisplay) {
+			displayText = firstName + ' ' + lastName;
+		}
+		else {
+			displayText = lastName + ', ' + firstName;
 		}
 
-		return displayString;
+		if(firstName && lastName) {
+			ariaText = firstName + ' ' + lastName;
+		}
+		else {
+			ariaText = displayText;
+		}
+
+		const text = {
+			displayText,
+			ariaText
+		};
+		return text;
 	}
 
 	_goToPageNumber(newPage) {
@@ -589,8 +615,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(LitElement)) {
 	}
 
 	_renderLearnerRow(learnerData, outcomeHeaderData) {
-		const userNameDisplay = this._getUserNameDisplay(learnerData.firstName, learnerData.lastName);
-
+		const userNameText = this._getUserNameText(learnerData.firstName, learnerData.lastName, this._nameFirstLastFormat);
 		if (outcomeHeaderData.length === 0 || !learnerData.rowDataHref) {
 			return this._renderNoLearnerState(this.localize('learnerHasNoData', 'username', learnerData.firstName + ' ' + learnerData.lastName));
 		}
@@ -603,10 +628,10 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(LitElement)) {
 						href="${learnerData.gradesPageHref}"
 						class="d2l-link learner-name-label"
 						role="region"
-						aria-label=${this.localize('goToUserAchievementSummaryPage')}
-						title=${userNameDisplay}
+						aria-label=${this.localize('goToUserAchievementSummaryPage', 'name', userNameText.ariaText)}
+						title=${userNameText.displayText}
 					>
-						${userNameDisplay}
+						${userNameText.displayText}
 					</a>
 				</div>
 			</th>

--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -345,21 +345,6 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(LitElement)) {
 		);
 	}
 
-	_getUserAriaName(firstName, lastName) {
-		if (!firstName && !lastName) {
-			return this.localize('anonymousUser');
-		}
-		else if (!firstName) {
-			return lastName;
-		}
-		else if (!lastName) {
-			return firstName;
-		}
-		else {
-			return firstName + ' ' + lastName;
-		}
-	}
-
 	_getUserNameText(firstName, lastName, firstLastDisplay) {
 		let displayText, ariaText;
 

--- a/src/mastery-view-table/mastery-view-user-outcome-cell.js
+++ b/src/mastery-view-table/mastery-view-user-outcome-cell.js
@@ -279,15 +279,30 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 
 			const demonstratedLevel = demonstration.getDemonstratedLevel();
 			if (demonstratedLevel) {
-				hasManualOverride = demonstratedLevel.isManualOverride();
 				demonstratedLevel.onLevelChanged(loa => {
 					name = loa.getName();
 					color = loa.getColor();
 				});
 			}
+			demonstration.subEntitiesLoaded().then(() => {
+				let selectedLevelId = null, suggestedLevelId = null;
+				demonstration.getAllDemonstratableLevels().map(level => {
+					if(level.isSelected()) {
+						selectedLevelId = level.getLevelId();
+					}
+					if(level.isSuggested()) {
+						suggestedLevelId = level.getLevelId();
+					}
+				})
+
+				if(suggestedLevelId && selectedLevelId != suggestedLevelId) {
+					hasManualOverride = true;
+				}
+			});
 		});
 
 		entity.subEntitiesLoaded().then(() => {
+			
 			this._cellData = {
 				totalAssessments: activityCount,
 				totalEvaluatedAssessments: assessedActivityCount,

--- a/src/mastery-view-table/mastery-view-user-outcome-cell.js
+++ b/src/mastery-view-table/mastery-view-user-outcome-cell.js
@@ -8,6 +8,7 @@ import 'd2l-table/d2l-table.js';
 import { MasteryViewRowEntity } from '../entities/MasteryViewRowEntity';
 import '../custom-icons/visibility-hide.js';
 import '../custom-icons/visibility-show.js';
+import { Consts } from '../consts';
 
 const KEYCODES = {
 	ENTER: 13,
@@ -210,12 +211,11 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 		}
 
 		var assessmentInfo = '';
-
-		if (data.hasOverallAssessment) {
-			assessmentInfo += data.levelName + this.localize('commaSeparator');
+		if (data.levelName === Consts.noCoaLevelName) {
+			assessmentInfo += this.localize('notEvaluated') + this.localize('commaSeparator');
 		}
 		else {
-			assessmentInfo += this.localize('notEvaluated') + this.localize('commaSeparator');
+			assessmentInfo += data.levelName + this.localize('commaSeparator');
 		}
 
 		if (data.isManualOverride) {
@@ -269,14 +269,12 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 		const evalHref = cellEntity.getEvaluationHref();
 		const isOutOfDate = cellEntity.isOutdated();
 
-		let name = '-';
-		let color = '#FFFFFF';
+		let name = Consts.noCoaLevelName;
+		let color = Consts.noCoaLevelColor;
 		let isPublished = false;
 		let hasManualOverride = false;
-		let hasOverallDemonstration = false;
 
 		cellEntity.onCheckpointDemonstrationChanged(demonstration => {
-			hasOverallDemonstration = true;
 			isPublished = demonstration.isPublished();
 
 			const demonstratedLevel = demonstration.getDemonstratedLevel();
@@ -291,11 +289,10 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 
 		entity.subEntitiesLoaded().then(() => {
 			this._cellData = {
-				hasOverallAssessment: hasOverallDemonstration,
 				totalAssessments: activityCount,
 				totalEvaluatedAssessments: assessedActivityCount,
 				levelName: name,
-				levelColor: color + '1A',
+				levelColor: color + Consts.tenPercentAlphaHex,
 				isManualOverride: hasManualOverride,
 				outdated: isOutOfDate,
 				published: isPublished,

--- a/src/mastery-view-table/mastery-view-user-outcome-cell.js
+++ b/src/mastery-view-table/mastery-view-user-outcome-cell.js
@@ -287,22 +287,21 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 			demonstration.subEntitiesLoaded().then(() => {
 				let selectedLevelId = null, suggestedLevelId = null;
 				demonstration.getAllDemonstratableLevels().map(level => {
-					if(level.isSelected()) {
+					if (level.isSelected()) {
 						selectedLevelId = level.getLevelId();
 					}
-					if(level.isSuggested()) {
+					if (level.isSuggested()) {
 						suggestedLevelId = level.getLevelId();
 					}
-				})
+				});
 
-				if(suggestedLevelId && selectedLevelId != suggestedLevelId) {
+				if (suggestedLevelId && selectedLevelId !== suggestedLevelId) {
 					hasManualOverride = true;
 				}
 			});
 		});
 
 		entity.subEntitiesLoaded().then(() => {
-			
 			this._cellData = {
 				totalAssessments: activityCount,
 				totalEvaluatedAssessments: assessedActivityCount,


### PR DESCRIPTION
Corrects two failing cases for how MV determines whether to show an * next to an achievement level:
- An auto-calculated achievement overridden to have no overall achievement level (should appear)
- A manually selected achievement level with no auto-calculation (should not appear)

Also adds/corrects some text for screen readers.