### PR TITLE
Change refresh event name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.27",
+  "version": "1.1.29",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "scripts": {
     "lang:build": "lang-build -es \"\t\" -c langtools/config.json",

--- a/src/overall-achievement-tile/overall-achievement-tile.js
+++ b/src/overall-achievement-tile/overall-achievement-tile.js
@@ -148,12 +148,12 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
 	connectedCallback() {
 		super.connectedCallback();
-		window.addEventListener('d2l-save-evaluation', this.refreshEntity);
+		window.addEventListener('d2l-refresh-outcome-activities', this.refreshEntity);
 	}
 
 	disconnectedCallback() {
 		super.disconnectedCallback();
-		window.removeEventListener('d2l-save-evaluation', this.refreshEntity);
+		window.removeEventListener('d2l-refresh-outcome-activities', this.refreshEntity);
 	}
 
 	render() {

--- a/src/primary-panel/primary-panel.js
+++ b/src/primary-panel/primary-panel.js
@@ -74,12 +74,12 @@ class PrimaryPanel extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
 	connectedCallback() {
 		super.connectedCallback();
-		window.addEventListener('d2l-save-evaluation', this.refreshEntity);
+		window.addEventListener('d2l-refresh-outcome-activities', this.refreshEntity);
 	}
 
 	disconnectedCallback() {
 		super.disconnectedCallback();
-		window.removeEventListener('d2l-save-evaluation', this.refreshEntity);
+		window.removeEventListener('d2l-refresh-outcome-activities', this.refreshEntity);
 	}
 
 	render() {

--- a/src/trend/big-trend.js
+++ b/src/trend/big-trend.js
@@ -284,12 +284,12 @@ class BigTrend extends TrendMixin(LocalizeMixin(RtlMixin(LitElement))) {
 
 	connectedCallback() {
 		super.connectedCallback();
-		window.addEventListener('d2l-save-evaluation', this.refreshEntity);
+		window.addEventListener('d2l-refresh-outcome-activities', this.refreshEntity);
 	}
 
 	disconnectedCallback() {
 		super.disconnectedCallback();
-		window.removeEventListener('d2l-save-evaluation', this.refreshEntity);
+		window.removeEventListener('d2l-refresh-outcome-activities', this.refreshEntity);
 	}
 
 	firstUpdated() {


### PR DESCRIPTION
These 3 PRs are related to each other:
https://github.com/BrightspaceHypermediaComponents/consistent-evaluation/pull/181
https://github.com/Brightspace/outcomes-level-of-achievement-ui/pull/64
https://github.com/Brightspace/d2l-outcomes-overall-achievement/pull/59

Recently, the COA `publish` action now has a field that requires knowledge of the state of the COA component and the feedback contents. As a result, the `publish` action is now moved to the COA component itself and is called using the `d2l-save-evaluation` event. The COA component fires the `d2l-refresh-outcome-activities` event after publishing an outcome.

Changes:
* Change the event listeners to use `d2l-refresh-outcome-activities` instead of `d2l-save-evaluation`

https://rally1.rallydev.com/#/detail/defect/455925703800?fdp=true
