### PR TITLE
Refresh feedback upon saving evaluation

### DIFF
--- a/src/entities/DemonstrationEntity.js
+++ b/src/entities/DemonstrationEntity.js
@@ -70,8 +70,8 @@ export class DemonstrationEntity extends Entity {
 	}
 
 	onFeedbackChanged(onChange) {
-		const href = this._feedbackHref();
-		href && this._subEntity(FeedbackListEntity, href, onChange);
+		const feedbackEntity = this._getFeedback();
+		feedbackEntity && this._subEntity(FeedbackListEntity, feedbackEntity, onChange);
 	}
 
 	onUserActivityUsageChanged(onChange) {
@@ -79,12 +79,12 @@ export class DemonstrationEntity extends Entity {
 		href && this._subEntity(UserActivityUsageEntity, href, onChange);
 	}
 
-	_feedbackHref() {
-		if (!this._entity || !this._entity.hasLinkByRel(DemonstrationEntity.links.feedback)) {
+	_getFeedback() {
+		if (!this._entity || !this._entity.hasSubEntityByClass(FeedbackListEntity.class)) {
 			return;
 		}
 
-		return this._entity.getLinkByRel(DemonstrationEntity.links.feedback).href;
+		return this._entity.getSubEntityByClass(FeedbackListEntity.class);
 	}
 
 	_userActivityUsageHref() {

--- a/src/entities/DemonstrationEntity.js
+++ b/src/entities/DemonstrationEntity.js
@@ -45,14 +45,6 @@ export class DemonstrationEntity extends Entity {
 		return levelEntity && new DemonstratableLevelEntity(this, levelEntity);
 	}
 
-	getFeedbackHref() {
-		if (!this._entity || !this._entity.hasLinkByRel(DemonstrationEntity.links.feedback)) {
-			return;
-		}
-
-		return this._entity.getLinkByRel(DemonstrationEntity.links.feedback).href;
-	}
-
 	getSelfHref() {
 		if (!this._entity || !this._entity.hasLinkByRel('self')) {
 			return null;
@@ -78,13 +70,21 @@ export class DemonstrationEntity extends Entity {
 	}
 
 	onFeedbackChanged(onChange) {
-		const href = this.getFeedbackHref();
+		const href = this._feedbackHref();
 		href && this._subEntity(FeedbackListEntity, href, onChange);
 	}
 
 	onUserActivityUsageChanged(onChange) {
 		const href = this._userActivityUsageHref();
 		href && this._subEntity(UserActivityUsageEntity, href, onChange);
+	}
+
+	_feedbackHref() {
+		if (!this._entity || !this._entity.hasLinkByRel(DemonstrationEntity.links.feedback)) {
+			return;
+		}
+
+		return this._entity.getLinkByRel(DemonstrationEntity.links.feedback).href;
 	}
 
 	_userActivityUsageHref() {

--- a/src/entities/DemonstrationEntity.js
+++ b/src/entities/DemonstrationEntity.js
@@ -45,6 +45,14 @@ export class DemonstrationEntity extends Entity {
 		return levelEntity && new DemonstratableLevelEntity(this, levelEntity);
 	}
 
+	getFeedbackHref() {
+		if (!this._entity || !this._entity.hasLinkByRel(DemonstrationEntity.links.feedback)) {
+			return;
+		}
+
+		return this._entity.getLinkByRel(DemonstrationEntity.links.feedback).href;
+	}
+
 	getSelfHref() {
 		if (!this._entity || !this._entity.hasLinkByRel('self')) {
 			return null;
@@ -70,21 +78,13 @@ export class DemonstrationEntity extends Entity {
 	}
 
 	onFeedbackChanged(onChange) {
-		const href = this._feedbackHref();
+		const href = this.getFeedbackHref();
 		href && this._subEntity(FeedbackListEntity, href, onChange);
 	}
 
 	onUserActivityUsageChanged(onChange) {
 		const href = this._userActivityUsageHref();
 		href && this._subEntity(UserActivityUsageEntity, href, onChange);
-	}
-
-	_feedbackHref() {
-		if (!this._entity || !this._entity.hasLinkByRel(DemonstrationEntity.links.feedback)) {
-			return;
-		}
-
-		return this._entity.getLinkByRel(DemonstrationEntity.links.feedback).href;
 	}
 
 	_userActivityUsageHref() {

--- a/src/overall-achievement-tile/overall-achievement-tile.js
+++ b/src/overall-achievement-tile/overall-achievement-tile.js
@@ -143,7 +143,6 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 		this._activityName = '';
 		this._levelColor = '';
 		this._levelName = '';
-		this._feedbackHref = undefined;
 		this.refreshEntity = this._refreshEntity.bind(this);
 	}
 
@@ -198,12 +197,11 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
 	_onEntityChanged(entity) {
 		if (entity) {
-			let levelName, levelColor, accessDate, feedback, feedbackHref, published;
+			let levelName, levelColor, accessDate, feedback, published;
 			entity.onAssessedDemonstrationChanged(demonstration => {
 				if (!demonstration) {
 					return;
 				}
-				feedbackHref = demonstration.getFeedbackHref();
 				demonstration.onFeedbackChanged(feedbackList => {
 					feedback = feedbackList.getFeedback();
 				});
@@ -224,7 +222,6 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 				this._accessDate = new Date(accessDate);
 				this._activityName = activityName;
 				this._feedback = feedback;
-				this._feedbackHref = feedbackHref;
 				this._levelColor = levelColor;
 				this._levelName = levelName;
 				this._published = published;
@@ -234,9 +231,6 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
 	_refreshEntity() {
 		window.D2L.Siren.EntityStore.fetch(this.href, this.token, true);
-		if (this._feedbackHref) {
-			window.D2L.Siren.EntityStore.fetch(this._feedbackHref, this.token, true);
-		}
 	}
 
 	_renderFeedback(feedbackData) {

--- a/src/overall-achievement-tile/overall-achievement-tile.js
+++ b/src/overall-achievement-tile/overall-achievement-tile.js
@@ -143,6 +143,7 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 		this._activityName = '';
 		this._levelColor = '';
 		this._levelName = '';
+		this._feedbackHref = undefined;
 		this.refreshEntity = this._refreshEntity.bind(this);
 	}
 
@@ -197,11 +198,12 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
 	_onEntityChanged(entity) {
 		if (entity) {
-			let levelName, levelColor, accessDate, feedback, published;
+			let levelName, levelColor, accessDate, feedback, feedbackHref, published;
 			entity.onAssessedDemonstrationChanged(demonstration => {
 				if (!demonstration) {
 					return;
 				}
+				feedbackHref = demonstration.getFeedbackHref();
 				demonstration.onFeedbackChanged(feedbackList => {
 					feedback = feedbackList.getFeedback();
 				});
@@ -222,6 +224,7 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 				this._accessDate = new Date(accessDate);
 				this._activityName = activityName;
 				this._feedback = feedback;
+				this._feedbackHref = feedbackHref;
 				this._levelColor = levelColor;
 				this._levelName = levelName;
 				this._published = published;
@@ -231,6 +234,9 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
 	_refreshEntity() {
 		window.D2L.Siren.EntityStore.fetch(this.href, this.token, true);
+		if (this._feedbackHref) {
+			window.D2L.Siren.EntityStore.fetch(this._feedbackHref, this.token, true);
+		}
 	}
 
 	_renderFeedback(feedbackData) {


### PR DESCRIPTION
Feedback wasn't refreshed when saving an evaluation.
Changes:
* Get the href of the feedback and re-fetch it upon saving an evaluation