### PR TITLE
Localize overall achievement text

### DIFF
--- a/data/outcome-activity-collections/10/activities/a11.json
+++ b/data/outcome-activity-collections/10/activities/a11.json
@@ -6,7 +6,7 @@
 		"item"
 	],
 	"properties": {
-		"name": "Assignment 11",
+		"name": "",
 		"type": "Dropbox"
 	},
 	"entities": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.32",
+  "version": "1.1.37",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "scripts": {
     "lang:build": "lang-build -es \"\t\" -c langtools/config.json",

--- a/src/LocalizeMixin.js
+++ b/src/LocalizeMixin.js
@@ -1,5 +1,7 @@
 import { LocalizeMixin as CoreLocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin';
 
+import { Consts } from './consts.js';
+
 export const LocalizeMixin = (superclass) => class extends CoreLocalizeMixin(superclass) {
 
 	static async getLocalizeResources(langs) {
@@ -62,6 +64,18 @@ export const LocalizeMixin = (superclass) => class extends CoreLocalizeMixin(sup
 			language: 'en',
 			resources: translations.val
 		};
+	}
+
+	localizeActivityName(name) {
+		if (!name || name.trim() === '') {
+			return this.localize('untitled');
+		}
+
+		if (name === Consts.overallAchievementActivityName) {
+			return this.localize('labelOverallAchievement');
+		}
+
+		return name;
 	}
 
 };

--- a/src/assessment-list/assessment-entry.js
+++ b/src/assessment-list/assessment-entry.js
@@ -200,7 +200,7 @@ export class AssessmentEntry extends EntityMixinLit(LocalizeMixin(LitElement)) {
 				<button id="card" class="d2l-more-less-toggle" ?disabled="${!this._link}" @click="${this._onClick}">
 					<div id="card-header">
 						<div id="header-left">
-							<h4 class="d2l-heading-4" id="activity-name">${this._activityName}</h4>
+							<h4 class="d2l-heading-4" id="activity-name">${this.localizeActivityName(this._activityName, this.localize)}</h4>
 							<div>${this._renderAttempt(this._attempt)}</div>
 						</div>
 						<div id="loa">

--- a/src/assessment-list/assessment-entry.js
+++ b/src/assessment-list/assessment-entry.js
@@ -200,7 +200,7 @@ export class AssessmentEntry extends EntityMixinLit(LocalizeMixin(LitElement)) {
 				<button id="card" class="d2l-more-less-toggle" ?disabled="${!this._link}" @click="${this._onClick}">
 					<div id="card-header">
 						<div id="header-left">
-							<h4 class="d2l-heading-4" id="activity-name">${this.localizeActivityName(this._activityName, this.localize)}</h4>
+							<h4 class="d2l-heading-4" id="activity-name">${this.localizeActivityName(this._activityName)}</h4>
 							<div>${this._renderAttempt(this._attempt)}</div>
 						</div>
 						<div id="loa">

--- a/src/consts.js
+++ b/src/consts.js
@@ -4,5 +4,6 @@ export const Consts = {
 	},
 	noCoaLevelName: '-',
 	noCoaLevelColor: '#FFFFFF',
-	tenPercentAlphaHex: '1A',
+	overallAchievementActivityName: 'Overall Achievement',
+	tenPercentAlphaHex: '1A'
 };

--- a/src/overall-achievement-tile/overall-achievement-tile.js
+++ b/src/overall-achievement-tile/overall-achievement-tile.js
@@ -22,6 +22,7 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
 	static get properties() {
 		return {
+			_activityName: { attribute: false },
 			_feedback: { attribute: false },
 			_levelColor: { attribute: false },
 			_levelName: { attribute: false },
@@ -156,7 +157,7 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 						<d2l-icon icon="tier2:grade"></d2l-icon> 
 						<div id="card-info">
 							<div id="title">
-								<h4 class="d2l-heading-4" id="activity-name">${this.localize('labelOverallAchievement')}</h4>
+								<h4 class="d2l-heading-4" id="activity-name">${this.localizeActivityName(this._activityName, this.localize)}</h4>
 								<div>${this._renderVisibilityIcon(this._published)}</div> 
 							</div>
 							${dateElement}
@@ -204,9 +205,11 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 				published = demonstration.isPublished();
 				accessDate = demonstration.getDateAssessed();
 			});
+			const activityName = entity.getName();
 
 			entity.subEntitiesLoaded().then(() => {
 				this._accessDate = new Date(accessDate);
+				this._activityName = activityName;
 				this._feedback = feedback;
 				this._levelColor = levelColor;
 				this._levelName = levelName;

--- a/src/overall-achievement-tile/overall-achievement-tile.js
+++ b/src/overall-achievement-tile/overall-achievement-tile.js
@@ -22,7 +22,6 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 
 	static get properties() {
 		return {
-			_activityName: { attribute: false },
 			_feedback: { attribute: false },
 			_levelColor: { attribute: false },
 			_levelName: { attribute: false },
@@ -157,7 +156,7 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 						<d2l-icon icon="tier2:grade"></d2l-icon> 
 						<div id="card-info">
 							<div id="title">
-								<h4 class="d2l-heading-4" id="activity-name">${this._activityName}</h4>
+								<h4 class="d2l-heading-4" id="activity-name">${this.localize('labelOverallAchievement')}</h4>
 								<div>${this._renderVisibilityIcon(this._published)}</div> 
 							</div>
 							${dateElement}
@@ -205,11 +204,9 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 				published = demonstration.isPublished();
 				accessDate = demonstration.getDateAssessed();
 			});
-			const activityName = entity.getName();
 
 			entity.subEntitiesLoaded().then(() => {
 				this._accessDate = new Date(accessDate);
-				this._activityName = activityName;
 				this._feedback = feedback;
 				this._levelColor = levelColor;
 				this._levelName = levelName;

--- a/src/overall-achievement-tile/overall-achievement-tile.js
+++ b/src/overall-achievement-tile/overall-achievement-tile.js
@@ -157,7 +157,7 @@ class OverallAchievementTile extends EntityMixinLit(LocalizeMixin(LitElement)) {
 						<d2l-icon icon="tier2:grade"></d2l-icon> 
 						<div id="card-info">
 							<div id="title">
-								<h4 class="d2l-heading-4" id="activity-name">${this.localizeActivityName(this._activityName, this.localize)}</h4>
+								<h4 class="d2l-heading-4" id="activity-name">${this.localizeActivityName(this._activityName)}</h4>
 								<div>${this._renderVisibilityIcon(this._published)}</div> 
 							</div>
 							${dateElement}

--- a/src/trend/big-trend.js
+++ b/src/trend/big-trend.js
@@ -472,7 +472,7 @@ class BigTrend extends TrendMixin(LocalizeMixin(RtlMixin(LitElement))) {
 			const groupDate = formatDate(group.date, { format: 'MMMM d, yyyy' });
 			const groupId = formatDate(group.date, { format: 'yyyy-MM' });
 			const groupLabel = this._getGroupLabel(group);
-			const groupName = this.localizeActivityName(group.name, this.localize);
+			const groupName = this.localizeActivityName(group.name);
 			const groupType = group.type;
 
 			if (group.type === 'checkpoint-item' && group.unpublishedCoa && this.hideUnpublishedCoa) {

--- a/src/trend/big-trend.js
+++ b/src/trend/big-trend.js
@@ -472,7 +472,7 @@ class BigTrend extends TrendMixin(LocalizeMixin(RtlMixin(LitElement))) {
 			const groupDate = formatDate(group.date, { format: 'MMMM d, yyyy' });
 			const groupId = formatDate(group.date, { format: 'yyyy-MM' });
 			const groupLabel = this._getGroupLabel(group);
-			let groupName = (!group.name || group.name.trim() === '') ? this.localize('untitled') : group.name;
+			const groupName = this.localizeActivityName(group.name, this.localize);
 			const groupType = group.type;
 
 			if (group.type === 'checkpoint-item' && group.unpublishedCoa && this.hideUnpublishedCoa) {
@@ -483,7 +483,6 @@ class BigTrend extends TrendMixin(LocalizeMixin(RtlMixin(LitElement))) {
 			switch (groupType.toLowerCase()) {
 				case 'checkpoint-item':
 					type = BarTypes.Diamond;
-					groupName = this.localize('labelOverallAchievement');
 					break;
 				default:
 					type = BarTypes.Bar;


### PR DESCRIPTION
Translates the overall achievement tile label to a user's locale. Also shows activities with empty names as "untitled" (or its translation) in the assessment list to be consistent with the trend graph.