### PR TITLE
US123881 - Add license checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+env:
+  NODE_VERSION: 14 # Latest LTS
 jobs:
   lint:
     name: Lint
@@ -15,7 +17,7 @@ jobs:
       - name: Set up node
         uses: Brightspace/third-party-actions@actions/setup-node
         with:
-          node-version: 14 # Latest LTS
+          node-version: ${{env.NODE_VERSION}}
       - name: Set up cache
         uses: Brightspace/third-party-actions@actions/cache
         id: cache
@@ -27,3 +29,27 @@ jobs:
         run: npm ci
       - name: Lint (JavaScript)
         run: npm run lint:eslint
+  check-licenses:
+    name: Check Licenses
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: Brightspace/third-party-actions@actions/checkout
+      - name: Set up node
+        uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version: ${{env.NODE_VERSION}}
+      - name: Set up cache
+        uses: Brightspace/third-party-actions@actions/cache
+        id: cache
+        with:
+          path: '**/node_modules'
+          key: npm-${{ hashFiles('**/package-lock.json') }}
+      - name: Install dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+      - name: Check licenses
+        run: |
+          npm install d2l-license-checker --no-save
+          npx license-checker-ci

--- a/.licensechecker.json
+++ b/.licensechecker.json
@@ -1,0 +1,9 @@
+{
+  "acceptedScopes": [
+    "d2l"
+  ],
+  "manualOverrides": {
+    "d2l-polymer-langtools@^1.4.0": "Public-Domain",
+    "valid-url@^1.0.9": "MIT"
+  }
+}


### PR DESCRIPTION
Add license checker to catch any licenses that may not be inline with our open source standards. This is something all repos using node are supposed to use. I recently added it to https://github.com/BrightspaceUI/core/pull/924.