### PR TITLE
Remove unneeded dependency d2l-alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2050,14 +2050,6 @@
         "which": "^2.0.1"
       }
     },
-    "d2l-alert": {
-      "version": "github:BrightspaceUI/alert#3ca1e0029c3201461e1415d77b3ea7140fc3e9ac",
-      "from": "github:BrightspaceUI/alert#semver:^4",
-      "requires": {
-        "@brightspace-ui/core": "^1.44",
-        "@polymer/polymer": "^3.0.0"
-      }
-    },
     "d2l-colors": {
       "version": "github:BrightspaceUI/colors#eca32f3d4caff4e739fe4e87c6a2eb15ea1f19a9",
       "from": "github:BrightspaceUI/colors#semver:^4",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@brightspace-ui/core": "^1.113.0",
-    "d2l-alert": "github:BrightspaceUI/alert#semver:^4",
     "d2l-resize-aware": "github:BrightspaceUI/resize-aware#semver:^1",
     "d2l-table": "github:BrightspaceUI/table#semver:^2",
     "d2l-telemetry-browser-client": "github:Brightspace/d2l-telemetry-browser-client#semver:^1",

--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -20,8 +20,8 @@ import '../custom-icons/RightArrow.js';
 
 import 'd2l-table/d2l-table.js';
 import 'd2l-table/d2l-scroll-wrapper.js';
-import 'd2l-alert/d2l-alert.js';
 
+import '@brightspace-ui/core/components/alert/alert.js';
 import '@brightspace-ui/core/components/alert/alert-toast.js';
 import '@brightspace-ui/core/components/typography/typography.js';
 import '@brightspace-ui/core/components/button/button.js';


### PR DESCRIPTION
The `d2l-alert` component is now part of BrightspaceUI/core. No need to pull in the archived version. Resolves #96.