### PR TITLE
Manual translations fixes (master)

### DIFF
--- a/lang/cy.js
+++ b/lang/cy.js
@@ -61,5 +61,5 @@ export default {
 	tooltipUserOutcomeAssessments: "Cafodd {numAssessed} o {numTotal} o weithgareddau eu hasesu",
 	trend: "Tuedd",
 	untitled: "Dideitl",
-	viewCourseIntentList: "Gweld rhestr bwriad y cwrs yn yr offer {outcomes, select, cymwyseddau {Competencies} disgwyliadau {Expectations} amcanion {Objectives} canlyniadau {Outcomes} safonau {Standards} arall {Standards}}"
+	viewCourseIntentList: "Gweld rhestr bwriad y cwrs yn yr offer {outcome, select, competencies {Cymwyseddau} expectations {Eisgwyliadau} objectives {Amcanion} outcomes {Canlyniadau} standards {Safonau} other {Safonau}}"
 };

--- a/lang/de.js
+++ b/lang/de.js
@@ -12,7 +12,7 @@ export default {
 	firstUseAlertToastMessage: "Die Ansicht „Lernerfolg“ wird automatisch mit der Methode „am häufigsten“ berechnet",
 	goToNextPage: "Gehen Sie zur nächsten Seite in der Tabelle.",
 	goToPreviousPage: "Gehen Sie zur vorherigen Seite in der Tabelle.",
-	goToUserAchievementSummaryPage: "Drücken Sie die Leertaste oder Eingabetaste, um die Seite mit der Zusammenfassung der Lernerfolge von {Name} zu öffnen.",
+	goToUserAchievementSummaryPage: "Drücken Sie die Leertaste oder Eingabetaste, um die Seite mit der Zusammenfassung der Lernerfolge von {name} zu öffnen.",
 	headingDate: "Datum",
 	headingEvidence: "Nachweisname",
 	headingLoa: "Erreichte Stufe",
@@ -34,7 +34,7 @@ export default {
 	newPageSizeLiveText: "{pageSize} Zeilen pro Seite werden angezeigt.",
 	noAlignedOutcomes: "Um die Ansicht „Lernerfolge“ zu verwenden, gleichen Sie zunächst die {outcome, select, competencies {Kompetenzen} expectations {Erwartungen} objectives {Ziele} outcomes {Ergebnisse} standards {Standards} other {Standards}} auf der Bearbeitungsseite der Aktivität ab.",
 	noEnrolledLearners: "Keine angemeldeten Teilnehmer am Kurs.",
-	noScaleInstructor: "Um den Lernfortschritt beim Erreichen dieser {result, select, competencies {Kompetenzen} expectations {Erwartungen} objectives {Ziele} outcomes {Ergebnisse} standards {Standards} other {Standards}} anzuzeigen, erstellen Sie eine Erfolgsskala und wählen Sie sie aus.",
+	noScaleInstructor: "Um den Lernfortschritt beim Erreichen dieser {outcome, select, competencies {Kompetenzen} expectations {Erwartungen} objectives {Ziele} outcomes {Ergebnisse} standards {Standards} other {Standards}} anzuzeigen, erstellen Sie eine Erfolgsskala und wählen Sie sie aus.",
 	noScaleStudent: "Es wurde keine Skala festgelegt, um das Erreichen von {outcome, select, competencies {Kompetenzen} expectations {Erwartungen} objectives {Zielen} outcomes {Ergebnissen} standards {Standards} other {Standards}} zu messen.",
 	notAssessed: "Nicht bewertet",
 	notEvaluated: "Nicht bewertet",
@@ -61,5 +61,5 @@ export default {
 	tooltipUserOutcomeAssessments: "{numAssessed} von {numTotal} Aktivitäten werden bewertet",
 	trend: "Trend",
 	untitled: "ohne Titel",
-	viewCourseIntentList: "Sehen Sie die Kurszielliste im {outcomes, select, competencies {Kompetenzen} expectations {Erwartungen} objectives {Ziele} outcomes {Ergebnisse} standards {Standards} other {Standards}}-Tool"
+	viewCourseIntentList: "Sehen Sie die Kurszielliste im {outcome, select, competencies {Kompetenzen} expectations {Erwartungen} objectives {Ziele} outcomes {Ergebnisse} standards {Standards} other {Standards}}-Tool"
 };

--- a/lang/es.js
+++ b/lang/es.js
@@ -45,7 +45,7 @@ export default {
 	pageSelectOptionText: "{currentPage} de {pageCount}",
 	pageSizeSelectOptionText: "{pageSize} por página",
 	percentLabel: "{percentage}%",
-	periodSeparator: "De",
+	periodSeparator: ".",
 	published: "Publicada",
 	releaseAllBtn: "Publicar todo",
 	releaseAllTxt: "¿Publicar los logros generales de todos los estudiantes en el curso?",
@@ -61,5 +61,5 @@ export default {
 	tooltipUserOutcomeAssessments: "Se evalúan {numAssessed} de {numTotal} actividades",
 	trend: "Tendencia",
 	untitled: "Sin título",
-	viewCourseIntentList: "Ver la lista de metas en la herramienta {outcomes, select, competencies {Competencias} expectations {Expectativas} objectives {Objetivos} outcomes {Resultados} standards {Estándares} other {Estándares}}"
+	viewCourseIntentList: "Ver la lista de metas en la herramienta {outcome, select, competencies {Competencias} expectations {Expectativas} objectives {Objetivos} outcomes {Resultados} standards {Estándares} other {Estándares}}"
 };

--- a/lang/ja.js
+++ b/lang/ja.js
@@ -61,5 +61,5 @@ export default {
 	tooltipUserOutcomeAssessments: "{numTotal} 件のアクティビティのうち {numAssessed} 件が評価されます",
 	trend: "傾向",
 	untitled: "無題",
-	viewCourseIntentList: "{outcomes, select, competencies {コンピテンシ} expectations {期待} objectives {目的} outcomes {結果} standards {標準} other {標準}}ツールにコースインテントリストを表示"
+	viewCourseIntentList: "{outcome, select, competencies {コンピテンシ} expectations {期待} objectives {目的} outcomes {結果} standards {標準} other {標準}}ツールにコースインテントリストを表示"
 };

--- a/lang/pt.js
+++ b/lang/pt.js
@@ -61,5 +61,5 @@ export default {
 	tooltipUserOutcomeAssessments: "{numAssessed} de {numTotal} atividades foram avaliadas",
 	trend: "Tendência",
 	untitled: "Sem título",
-	viewCourseIntentList: "Visualizar a lista de intenção de curso na ferramenta {outcomes, select, competencies {Competências} expectations {Expectativas} objectives {Objetivos} outcomes {Resultados} standards {Padrões} other {Padrões}}"
+	viewCourseIntentList: "Visualizar a lista de intenção de curso na ferramenta {outcome, select, competencies {Competências} expectations {Expectativas} objectives {Objetivos} outcomes {Resultados} standards {Padrões} other {Padrões}}"
 };

--- a/lang/tr.js
+++ b/lang/tr.js
@@ -32,7 +32,7 @@ export default {
 	name: "Ad",
 	newPageSelectLiveText: "{pageNum} / {totalPages} sayfa seçildi.",
 	newPageSizeLiveText: "Sayfa başına {pageSize} satır görüntüleniyor.",
-	noAlignedOutcomes: "Uzmanlık Görünümünü kullanmak için etkinliğin düzenleme sayfasındaki ders etkinliklerini {outcomes, select, competencies {yeterlikler} expectations {beklentiler} objectives {hedefler} outcomes {kazanımlar} standards {standartlar} other {standartlar}} ile uyumlu hale getirin.",
+	noAlignedOutcomes: "Uzmanlık Görünümünü kullanmak için etkinliğin düzenleme sayfasındaki ders etkinliklerini {outcome, select, competencies {yeterlikler} expectations {beklentiler} objectives {hedefler} outcomes {kazanımlar} standards {standartlar} other {standartlar}} ile uyumlu hale getirin.",
 	noEnrolledLearners: "Derse kayıtlı öğrenci yok.",
 	noScaleInstructor: "Şunlara ulaşma konusundaki katılımcı ilerlemesini görmek için bir başarı ölçütü oluşturun ve seçin: {outcome, select, competencies {yeterlik} expectations {beklenti} objectives {hedef} outcomes {kazanım} standards {standart} other {standart}}.",
 	noScaleStudent: "{outcome, select, competencies {yeterlikler} expectations {beklentiler} objectives {hedefler} outcomes {kazanımlar} standards {standartlar} other {standartlar}} başarısı için bir ölçüt belirlenmedi.",
@@ -61,5 +61,5 @@ export default {
 	tooltipUserOutcomeAssessments: "{numTotal} etkinlikten {numAssesed} tanesi değerlendirildi",
 	trend: "Eğilim",
 	untitled: "Adsız",
-	viewCourseIntentList: "{outcomes, select, competencies {yeterlikler} expectations {beklentiler} objectives {hedefler} outcomes {kazanımlar} standards {standartlar} other {standartlar}} aracından ders amaç listesini görüntüleyin"
+	viewCourseIntentList: "{outcome, select, competencies {yeterlikler} expectations {beklentiler} objectives {hedefler} outcomes {kazanımlar} standards {standartlar} other {standartlar}} aracından ders amaç listesini görüntüleyin"
 };

--- a/lang/zh-tw.js
+++ b/lang/zh-tw.js
@@ -61,5 +61,5 @@ export default {
 	tooltipUserOutcomeAssessments: "共有 {numTotal} 個活動，已評量其中的 {numAssessed} 個活動",
 	trend: "趨勢",
 	untitled: "未命名",
-	viewCourseIntentList: "在{outcomes, select, competencies {能力} expectations {預期} objectives {目標} outcomes {成果} standards {標準} other {標準}}工具中檢視課程目的列表"
+	viewCourseIntentList: "在{outcome, select, competencies {能力} expectations {預期} objectives {目標} outcomes {成果} standards {標準} other {標準}}工具中檢視課程目的列表"
 };

--- a/lang/zh.js
+++ b/lang/zh.js
@@ -61,5 +61,5 @@ export default {
 	tooltipUserOutcomeAssessments: "{numTotal} 个活动中有 {numAssessed} 个活动已评估",
 	trend: "趋势",
 	untitled: "无标题",
-	viewCourseIntentList: "在 {outcomes, select, competencies {能力} expectations {预期} objectives {目标} outcomes {成果} standards {标准} other {标准}} 工具中查看课程目的列表"
+	viewCourseIntentList: "在 {outcome, select, competencies {能力} expectations {预期} objectives {目标} outcomes {成果} standards {标准} other {标准}} 工具中查看课程目的列表"
 };


### PR DESCRIPTION
There were issues related to the latest round of translations. Issues with `{}` mostly again. All of these are being itemized and reported to localization as per their request. All of them have been fixed in `20.21.2` branch already.