### PR TITLE
Double bump version to get it back inline with release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.47",
+  "version": "1.1.49",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.47",
+  "version": "1.1.49",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "scripts": {
     "lint": "npm run -s lint:eslint",


### PR DESCRIPTION
Will do another release after this. Really hope we can automate this in he future using something like `semantic-release` which is what `core` uses. There's stuff in the work for it but for now... this stays manual.