### PR TITLE
Fix spacing below search in mastery view

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@brightspace-ui/core": "^1.113.0",
+    "@open-wc/dedupe-mixin": "^1.3.0",
     "d2l-resize-aware": "github:BrightspaceUI/resize-aware#semver:^1",
     "d2l-table": "github:BrightspaceUI/table#semver:^2",
     "d2l-telemetry-browser-client": "github:Brightspace/d2l-telemetry-browser-client#semver:^1",

--- a/src/LocalizeMixin.js
+++ b/src/LocalizeMixin.js
@@ -1,7 +1,9 @@
-import { LocalizeMixin as CoreLocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin';
+import { LocalizeMixin as CoreLocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { Consts } from './consts.js';
+import { dedupeMixin } from '@open-wc/dedupe-mixin';
 
-export const LocalizeMixin = (superclass) => class extends CoreLocalizeMixin(superclass) {
+const LocalizeMixinInternal = (superclass) => class extends CoreLocalizeMixin(RtlMixin(superclass)) {
 
 	static async getLocalizeResources(langs) {
 		let translations;
@@ -90,3 +92,5 @@ export const LocalizeMixin = (superclass) => class extends CoreLocalizeMixin(sup
 	}
 
 };
+
+export const LocalizeMixin = dedupeMixin(LocalizeMixinInternal);

--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -276,8 +276,8 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 				#upper-controls-container {
 					border-spacing: 0px;
 					width: 60vw;
-					display:flex;
-					flex-direction:column;
+					display: flex;
+					flex-direction: column;
 				}
 
 				:host([dir="rtl"]) #search-input {
@@ -297,7 +297,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 					border: 1px solid var(--d2l-color-gypsum);
 					color: var(--d2l-color-ferrite);
 					margin-bottom: 18px;
-					display:block;
+					display: block;
 				}
 
 				.msg-container

--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -279,7 +279,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 				}
 
 				#search-publish-container {
-					margin-bottom: 18px;
+					padding-bottom: 18px;
 				}
 
 				#search-input {

--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -276,14 +276,19 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 				#upper-controls-container {
 					border-spacing: 0px;
 					width: 60vw;
+					display:flex;
+					flex-direction:column;
 				}
 
-				#search-publish-container {
-					padding-bottom: 18px;
+				:host([dir="rtl"]) #search-input {
+					margin-right: 0;
+					margin-left: 24px;
 				}
 
 				#search-input {
 					max-width: 270px;
+					margin-bottom: 18px;
+					margin-right: 24px;
 				}
 
 				.msg-container {
@@ -292,6 +297,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 					border: 1px solid var(--d2l-color-gypsum);
 					color: var(--d2l-color-ferrite);
 					margin-bottom: 18px;
+					display:block;
 				}
 
 				.msg-container
@@ -314,7 +320,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 				}
 
 				#bulk-action {
-					margin-left: 24px;
+					margin-bottom: 18px;
 				}
 
 				@media (min-width: 768px) {

--- a/src/trend/big-trend.js
+++ b/src/trend/big-trend.js
@@ -1,6 +1,5 @@
 import { LitElement, html, css } from 'lit-element';
 import { LocalizeMixin } from '../LocalizeMixin';
-import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin';
 import { TrendMixin } from './TrendMixin';
 import '@brightspace-ui/core/components/colors/colors';
 import '@brightspace-ui/core/components/icons/icon';
@@ -24,7 +23,7 @@ const BarTypes = Object.freeze({
 	Diamond: 'diamond'
 });
 
-class BigTrend extends TrendMixin(LocalizeMixin(RtlMixin(LitElement))) {
+class BigTrend extends TrendMixin(LocalizeMixin(LitElement)) {
 
 	static get is() { return 'd2l-coa-big-trend'; }
 


### PR DESCRIPTION
When you have a large number of standards so the table is off the screen using `margin` doesn't seem to work. Switching to use `padding` works in both the case where the table is larger then the viewable screen and when it is within the contents on the screen.

Tested with **Chrome**, **Firefox** and **Edge**. Tested in simulated mobile mode. Tested that stick header and first column are unaffected.

**Before:**
![before](https://user-images.githubusercontent.com/9043211/107394590-0b45e480-6aca-11eb-9fe5-51b127a208ce.PNG)

**After:**
![atfer](https://user-images.githubusercontent.com/9043211/107394619-113bc580-6aca-11eb-954c-9cb243529e70.PNG)
