### PR TITLE
Fix-up first use alert padding

### DIFF
--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -155,7 +155,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 		return [
 			css`
 				#first-use-alert {
-					margin-bottom: 18px;
+					padding-bottom: 18px;
 				}
 
 				#scroll-wrapper {
@@ -829,10 +829,12 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 			: this.localize('firstUseAlertToastMessageNone');
 
 		return html`
-			<d2l-alert has-close-button id="first-use-alert">
-				<div>${toastMessageText}</div>
-				<d2l-link small href=${mvSettingsLocation}>${this.localize('firstUseAlertSettingPageMessage')}</d2l-link>
-			</d2l-alert>
+			<div id="first-use-alert">
+				<d2l-alert has-close-button>
+					<div>${toastMessageText}</div>
+					<d2l-link small href=${mvSettingsLocation}>${this.localize('firstUseAlertSettingPageMessage')}</d2l-link>
+				</d2l-alert>
+			</div>
 		`;
 	}
 


### PR DESCRIPTION
Similar issue to https://github.com/Brightspace/d2l-outcomes-overall-achievement/pull/119. If we use margin it doesn't work when the table is larger then the visible screen.

Tested on **Chrome**, **Firefox** and **Edge**. Both in simulated mobile mode and not.

Before
![before](https://user-images.githubusercontent.com/9043211/107425457-fcbcf480-6aec-11eb-90b8-0b7f0b6c4c74.PNG)

After
![atfer](https://user-images.githubusercontent.com/9043211/107425467-ffb7e500-6aec-11eb-934b-00da7da1a82d.PNG)

After with controls
![with contorls](https://user-images.githubusercontent.com/9043211/107425474-02b2d580-6aed-11eb-8ca2-c40f9894378e.PNG)

After with control and search results
![image](https://user-images.githubusercontent.com/9043211/107425708-51f90600-6aed-11eb-8600-aeed5015620b.png)

After mobile
![mobile no control](https://user-images.githubusercontent.com/9043211/107425484-06def300-6aed-11eb-94f2-bebb50452972.PNG)

After mobile with controls
![mobile](https://user-images.githubusercontent.com/9043211/107425842-7f45b400-6aed-11eb-9bdc-465e0d6d2222.PNG)
