### PR TITLE
Add preserve symlink flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint:eslint": "eslint . --ext .js,.html",
     "format": "npm run format:eslint",
     "format:eslint": "npm run lint:eslint -- --fix",
-    "start": "es-dev-server --app-index demo/index.html --node-resolve --dedupe --watch --open"
+    "start": "es-dev-server --app-index demo/index.html --node-resolve --dedupe --watch --open --preserve-symlinks"
   },
   "author": "D2L Corporation",
   "license": "Apache-2.0",


### PR DESCRIPTION
Allows us to `npm link` in dependencies and then use them in the demo for testing.