### PR TITLE
Fix Mastery search control defects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.53",
+  "version": "1.1.54",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.53",
+  "version": "1.1.54",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "repository": "https://github.com/Brightspace/d2l-outcomes-overall-achievement.git",
   "scripts": {

--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -1116,7 +1116,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 	}
 
 	_renderUpperControls() {
-		if (!this._learnerRowsData || this._learnerRowsData.length === 0) {
+		if (this._learnerList.length === 0) {
 			return null;
 		}
 

--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -469,7 +469,6 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 		}
 
 		if (changedProperties.has('_filteredLearnerList')) {
-			this._learnerRowsData = this._getLearnerRowsData(this._filteredLearnerList, this._currentPage, this._rowsPerPage);
 			this._updatePageCount();
 		}
 
@@ -626,7 +625,9 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 	_goToPageNumber(newPage) {
 		this._currentPage = newPage;
 		var selector = this.shadowRoot.getElementById('page-select-menu');
-		selector.selectedIndex = newPage - 1;
+		if (selector) {
+			selector.selectedIndex = newPage - 1;
+		}
 		this._learnerRowsData = this._getLearnerRowsData(this._filteredLearnerList, this._currentPage, this._rowsPerPage);
 	}
 


### PR DESCRIPTION
Resolves two issues:
- Search controls no longer disappear when 0 results are returned (which made the page unusable until user refreshed)
- Searching from a page starting from the nth user where <n search results are returned now functions correctly instead of showing a "no learners" state

Related ticket: [DE41731](https://rally1.rallydev.com/#/57732444928d/custom/373260458992?detail=%2Fdefect%2F464449942372)