### PR TITLE
removing style mixins now that table supports borders automatially

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.56",
+  "version": "1.1.57",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.56",
+  "version": "1.1.57",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "repository": "https://github.com/Brightspace/d2l-outcomes-overall-achievement.git",
   "scripts": {

--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -158,24 +158,6 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 					padding-bottom: 18px;
 				}
 
-				#scroll-wrapper {
-					--d2l-scroll-wrapper-h-scroll: {
-						border-left: 1px dashed var(--d2l-color-mica);
-						border-right: 1px dashed var(--d2l-color-mica);
-					};
-
-					--d2l-scroll-wrapper-left: {
-						border-left: none;
-					};
-
-					--d2l-scroll-wrapper-right: {
-						border-right: none;
-					};
-
-					--d2l-scroll-wrapper-border-color: var(--d2l-color-mica);
-					--d2l-scroll-wrapper-background-color: var(--d2l-color-regolith);
-				}
-
 				#no-outcomes-container {
 					width: 100%;
 					display: flex;
@@ -993,7 +975,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 					</thead>
 					<tbody>
 						${this._renderTableBody(this._outcomeHeadersData, this._learnerRowsData)}
-					<tbody>
+					</tbody>
 				</table>
 			</d2l-table-wrapper>
 			${this._renderTableControls()}


### PR DESCRIPTION
In order to migrate table to Lit, we need to ditch these Polymer style mixins. I've [modified scroll-wrapper](https://github.com/BrightspaceUI/table/pull/228) so that whenever the `show-actions` attribute is present (which it is in table's usage), the dashed overflow borders appear automatically.

So no need to set these from here.