### PR TITLE
Switch to eslint brightspace/lit-config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": "brightspace/polymer-3-config"
+  "extends": "brightspace/lit-config"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.58",
+  "version": "1.1.59",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.58",
+  "version": "1.1.59",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "repository": "https://github.com/Brightspace/d2l-outcomes-overall-achievement.git",
   "scripts": {

--- a/src/LocalizeMixin.js
+++ b/src/LocalizeMixin.js
@@ -1,7 +1,7 @@
-import { LocalizeMixin as CoreLocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
-import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 import { Consts } from './consts.js';
+import { LocalizeMixin as CoreLocalizeMixin } from '@brightspace-ui/core/mixins/localize-mixin.js';
 import { dedupeMixin } from '@open-wc/dedupe-mixin';
+import { RtlMixin } from '@brightspace-ui/core/mixins/rtl-mixin.js';
 
 const LocalizeMixinInternal = (superclass) => class extends CoreLocalizeMixin(RtlMixin(superclass)) {
 

--- a/src/assessment-list/assessment-entry.js
+++ b/src/assessment-list/assessment-entry.js
@@ -1,18 +1,17 @@
-import { formatDate } from '@brightspace-ui/intl/lib/dateTime.js';
-import { css, html, LitElement } from 'lit-element';
-import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
-import { LocalizeMixin } from '../LocalizeMixin';
-import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
-import { DemonstrationEntity } from '../entities/DemonstrationEntity';
-import { unsafeHTML } from 'lit-html/directives/unsafe-html';
-import { bodySmallStyles, heading4Styles } from '@brightspace-ui/core/components/typography/styles';
-import '@brightspace-ui/core/components/typography/typography';
-import '@brightspace-ui/core/components/typography/styles';
-import '@brightspace-ui/core/components/icons/icon';
 import '@brightspace-ui/core/components/colors/colors';
+import '@brightspace-ui/core/components/icons/icon';
 import '@brightspace-ui/core/components/more-less/more-less';
+import '@brightspace-ui/core/components/typography/typography';
 import '../custom-icons/quote';
 import './assessment-skeleton';
+import { bodySmallStyles, heading4Styles } from '@brightspace-ui/core/components/typography/styles';
+import { css, html, LitElement } from 'lit-element';
+import { DemonstrationEntity } from '../entities/DemonstrationEntity';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
+import { formatDate } from '@brightspace-ui/intl/lib/dateTime.js';
+import { LocalizeMixin } from '../LocalizeMixin';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html';
 
 export class AssessmentEntry extends SkeletonMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
 

--- a/src/assessment-list/assessment-entry.js
+++ b/src/assessment-list/assessment-entry.js
@@ -1,11 +1,11 @@
 import { formatDate } from '@brightspace-ui/intl/lib/dateTime.js';
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { LocalizeMixin } from '../LocalizeMixin';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import { DemonstrationEntity } from '../entities/DemonstrationEntity';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html';
-import { heading4Styles, bodySmallStyles } from '@brightspace-ui/core/components/typography/styles';
+import { bodySmallStyles, heading4Styles } from '@brightspace-ui/core/components/typography/styles';
 import '@brightspace-ui/core/components/typography/typography';
 import '@brightspace-ui/core/components/typography/styles';
 import '@brightspace-ui/core/components/icons/icon';
@@ -15,7 +15,6 @@ import '../custom-icons/quote';
 import './assessment-skeleton';
 
 export class AssessmentEntry extends SkeletonMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
-	static get is() { return 'd2l-coa-assessment-entry'; }
 
 	static get properties() {
 		return {
@@ -186,6 +185,8 @@ export class AssessmentEntry extends SkeletonMixin(EntityMixinLit(LocalizeMixin(
 		this._link = '';
 		this.skeleton = true;
 	}
+
+	static get is() { return 'd2l-coa-assessment-entry'; }
 
 	render() {
 		if (this.skeleton) {

--- a/src/assessment-list/assessment-list.js
+++ b/src/assessment-list/assessment-list.js
@@ -1,12 +1,12 @@
-import { css, html, LitElement } from 'lit-element';
-import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
-import { LocalizeMixin } from '../LocalizeMixin';
-import { UserProgressOutcomeEntity } from '../entities/UserProgressOutcomeEntity';
-import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import '@brightspace-ui/core/components/colors/colors';
 import '@brightspace-ui/core/components/typography/typography';
 import './assessment-entry';
 import './assessment-skeleton';
+import { css, html, LitElement } from 'lit-element';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
+import { LocalizeMixin } from '../LocalizeMixin';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
+import { UserProgressOutcomeEntity } from '../entities/UserProgressOutcomeEntity';
 
 const excludedActivityTypes = [
 	'checkpoint-item'

--- a/src/assessment-list/assessment-list.js
+++ b/src/assessment-list/assessment-list.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { LocalizeMixin } from '../LocalizeMixin';
 import { UserProgressOutcomeEntity } from '../entities/UserProgressOutcomeEntity';
@@ -13,7 +13,6 @@ const excludedActivityTypes = [
 ];
 
 export class AssessmentList extends SkeletonMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
-	static get is() { return 'd2l-coa-assessment-list'; }
 
 	static get properties() {
 		return {
@@ -45,6 +44,8 @@ export class AssessmentList extends SkeletonMixin(EntityMixinLit(LocalizeMixin(L
 		this._assessmentList = [];
 		this.skeleton = true;
 	}
+
+	static get is() { return 'd2l-coa-assessment-list'; }
 
 	render() {
 		if (this.skeleton) {

--- a/src/assessment-list/assessment-skeleton.js
+++ b/src/assessment-list/assessment-skeleton.js
@@ -1,14 +1,10 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { LocalizeMixin } from '../LocalizeMixin';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import '@brightspace-ui/core/components/colors/colors';
 
 export class AssessmentSkeleton extends SkeletonMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
-
-	static get is() {
-		return 'd2l-coa-assessment-skeleton';
-	}
 
 	static get properties() {
 		return {};
@@ -125,6 +121,8 @@ export class AssessmentSkeleton extends SkeletonMixin(EntityMixinLit(LocalizeMix
 		this.skeleton = true;
 	}
 
+	static get is() { return 'd2l-coa-assessment-skeleton'; }
+
 	render() {
 		return html`
 			<div class="skeleton-container">
@@ -154,6 +152,7 @@ export class AssessmentSkeleton extends SkeletonMixin(EntityMixinLit(LocalizeMix
 			</div>
 		`;
 	}
+
 }
 
 customElements.define(AssessmentSkeleton.is, AssessmentSkeleton);

--- a/src/assessment-list/assessment-skeleton.js
+++ b/src/assessment-list/assessment-skeleton.js
@@ -1,8 +1,8 @@
+import '@brightspace-ui/core/components/colors/colors';
 import { css, html, LitElement } from 'lit-element';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { LocalizeMixin } from '../LocalizeMixin';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
-import '@brightspace-ui/core/components/colors/colors';
 
 export class AssessmentSkeleton extends SkeletonMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
 

--- a/src/assessment-summary/assessment-summary-skeleton.js
+++ b/src/assessment-summary/assessment-summary-skeleton.js
@@ -1,13 +1,9 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles';
 import '@brightspace-ui/core/components/colors/colors';
 
 export class AssessmentSummarySkeleton extends SkeletonMixin(LitElement) {
-
-	static get is() {
-		return 'd2l-coa-assessment-summary-skeleton';
-	}
 
 	static get properties() {
 		return {};
@@ -40,12 +36,15 @@ export class AssessmentSummarySkeleton extends SkeletonMixin(LitElement) {
 		this.skeleton = true;
 	}
 
+	static get is() { return 'd2l-coa-assessment-summary-skeleton';	}
+
 	render() {
 		return html`
         <p id="total-assessments-skeleton" class="d2l-label-text d2l-skeletize"></p>
         <div class="summary-bar-skeleton d2l-skeletize"></div>
 		`;
 	}
+
 }
 
 customElements.define(AssessmentSummarySkeleton.is, AssessmentSummarySkeleton);

--- a/src/assessment-summary/assessment-summary-skeleton.js
+++ b/src/assessment-summary/assessment-summary-skeleton.js
@@ -1,7 +1,7 @@
-import { css, html, LitElement } from 'lit-element';
-import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
-import { labelStyles } from '@brightspace-ui/core/components/typography/styles';
 import '@brightspace-ui/core/components/colors/colors';
+import { css, html, LitElement } from 'lit-element';
+import { labelStyles } from '@brightspace-ui/core/components/typography/styles';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
 export class AssessmentSummarySkeleton extends SkeletonMixin(LitElement) {
 

--- a/src/assessment-summary/assessment-summary.js
+++ b/src/assessment-summary/assessment-summary.js
@@ -1,11 +1,11 @@
-import { css, html, LitElement } from 'lit-element';
-import { labelStyles } from '@brightspace-ui/core/components/typography/styles';
-import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
-import { LocalizeMixin } from '../LocalizeMixin';
-import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
-import { OutcomeActivityCollectionEntity } from '../entities/OutcomeActivityCollectionEntity';
 import '../stacked-bar/stacked-bar';
 import './assessment-summary-skeleton.js';
+import { css, html, LitElement } from 'lit-element';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
+import { labelStyles } from '@brightspace-ui/core/components/typography/styles';
+import { LocalizeMixin } from '../LocalizeMixin';
+import { OutcomeActivityCollectionEntity } from '../entities/OutcomeActivityCollectionEntity';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
 const excludedActivityTypes = [
 	'checkpoint-item'

--- a/src/assessment-summary/assessment-summary.js
+++ b/src/assessment-summary/assessment-summary.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import { labelStyles } from '@brightspace-ui/core/components/typography/styles';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { LocalizeMixin } from '../LocalizeMixin';
@@ -12,7 +12,6 @@ const excludedActivityTypes = [
 ];
 
 class AssessmentSummary extends SkeletonMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
-	static get is() { return 'd2l-coa-assessment-summary'; }
 
 	static get properties() {
 		return {
@@ -49,6 +48,8 @@ class AssessmentSummary extends SkeletonMixin(EntityMixinLit(LocalizeMixin(LitEl
 		this.skeleton = true;
 	}
 
+	static get is() { return 'd2l-coa-assessment-summary'; }
+
 	render() {
 		if (this.skeleton) {
 			return html`
@@ -77,7 +78,7 @@ class AssessmentSummary extends SkeletonMixin(EntityMixinLit(LocalizeMixin(LitEl
 			super._entity = entity;
 		}
 	}
-	//
+
 	_onEntityChanged(entity) {
 		if (entity) {
 			const demonstrations = [];
@@ -99,6 +100,7 @@ class AssessmentSummary extends SkeletonMixin(EntityMixinLit(LocalizeMixin(LitEl
 			});
 		}
 	}
+
 }
 
 customElements.define(AssessmentSummary.is, AssessmentSummary);

--- a/src/custom-icons/LeftArrow.js
+++ b/src/custom-icons/LeftArrow.js
@@ -1,10 +1,7 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import '@brightspace-ui/core/components/icons/icon-custom.js';
 
 class LeftArrowIcon extends LitElement {
-	static get is() {
-		return 'd2l-icon-left-arrow';
-	}
 
 	static get properties() {
 		return {
@@ -30,6 +27,8 @@ class LeftArrowIcon extends LitElement {
 		`;
 	}
 
+	static get is() { return 'd2l-icon-left-arrow'; }
+
 	render() {
 		return this.hidden ? html`
 			<div class="empty-icon-container"></div>
@@ -41,6 +40,7 @@ class LeftArrowIcon extends LitElement {
 			</div>
 		`;
 	}
+
 }
 
 customElements.define(LeftArrowIcon.is, LeftArrowIcon);

--- a/src/custom-icons/LeftArrow.js
+++ b/src/custom-icons/LeftArrow.js
@@ -1,5 +1,5 @@
-import { css, html, LitElement } from 'lit-element';
 import '@brightspace-ui/core/components/icons/icon-custom.js';
+import { css, html, LitElement } from 'lit-element';
 
 class LeftArrowIcon extends LitElement {
 

--- a/src/custom-icons/RightArrow.js
+++ b/src/custom-icons/RightArrow.js
@@ -1,10 +1,7 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import '@brightspace-ui/core/components/icons/icon-custom.js';
 
 class RightArrowIcon extends LitElement {
-	static get is() {
-		return 'd2l-icon-right-arrow';
-	}
 
 	static get properties() {
 		return {
@@ -30,6 +27,8 @@ class RightArrowIcon extends LitElement {
 		`;
 	}
 
+	static get is() { return 'd2l-icon-right-arrow'; }
+
 	render() {
 		return this.hidden ? html`
 			<div class="empty-icon-container"></div>
@@ -41,6 +40,7 @@ class RightArrowIcon extends LitElement {
 			</div>
 		`;
 	}
+
 }
 
 customElements.define(RightArrowIcon.is, RightArrowIcon);

--- a/src/custom-icons/RightArrow.js
+++ b/src/custom-icons/RightArrow.js
@@ -1,5 +1,5 @@
-import { css, html, LitElement } from 'lit-element';
 import '@brightspace-ui/core/components/icons/icon-custom.js';
+import { css, html, LitElement } from 'lit-element';
 
 class RightArrowIcon extends LitElement {
 

--- a/src/custom-icons/quote.js
+++ b/src/custom-icons/quote.js
@@ -1,10 +1,7 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import '@brightspace-ui/core/components/icons/icon-custom';
 
 class QuoteIcon extends LitElement {
-	static get is() {
-		return 'd2l-icon-quote';
-	}
 
 	static get styles() {
 		return css`
@@ -18,6 +15,8 @@ class QuoteIcon extends LitElement {
 			}
 		`;
 	}
+
+	static get is() { return 'd2l-icon-quote'; }
 
 	render() {
 		return html`
@@ -36,6 +35,7 @@ class QuoteIcon extends LitElement {
 			</d2l-icon-custom>
 		`;
 	}
+
 }
 
 customElements.define(QuoteIcon.is, QuoteIcon);

--- a/src/custom-icons/quote.js
+++ b/src/custom-icons/quote.js
@@ -1,5 +1,5 @@
-import { css, html, LitElement } from 'lit-element';
 import '@brightspace-ui/core/components/icons/icon-custom';
+import { css, html, LitElement } from 'lit-element';
 
 class QuoteIcon extends LitElement {
 

--- a/src/custom-icons/visibility-hide.js
+++ b/src/custom-icons/visibility-hide.js
@@ -1,10 +1,7 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import '@brightspace-ui/core/components/icons/icon-custom';
 
 class VisibilityHideIcon extends LitElement {
-	static get is() {
-		return 'd2l-icon-visibility-hide';
-	}
 
 	static get styles() {
 		return css`
@@ -36,6 +33,8 @@ class VisibilityHideIcon extends LitElement {
 		`;
 	}
 
+	static get is() { return 'd2l-icon-visibility-hide'; }
+
 	render() {
 		return html`
 			<d2l-icon-custom>
@@ -54,6 +53,7 @@ class VisibilityHideIcon extends LitElement {
 			</d2l-icon-custom>
 		`;
 	}
+
 }
 
 customElements.define(VisibilityHideIcon.is, VisibilityHideIcon);

--- a/src/custom-icons/visibility-hide.js
+++ b/src/custom-icons/visibility-hide.js
@@ -1,5 +1,5 @@
-import { css, html, LitElement } from 'lit-element';
 import '@brightspace-ui/core/components/icons/icon-custom';
+import { css, html, LitElement } from 'lit-element';
 
 class VisibilityHideIcon extends LitElement {
 

--- a/src/custom-icons/visibility-show.js
+++ b/src/custom-icons/visibility-show.js
@@ -1,10 +1,7 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import '@brightspace-ui/core/components/icons/icon-custom';
 
 class VisibilityShowIcon extends LitElement {
-	static get is() {
-		return 'd2l-icon-visibility-show';
-	}
 
 	static get styles() {
 		return css`
@@ -19,6 +16,8 @@ class VisibilityShowIcon extends LitElement {
 		`;
 	}
 
+	static get is() { return 'd2l-icon-visibility-show'; }
+
 	render() {
 		return html`
 			<d2l-icon-custom>
@@ -28,6 +27,7 @@ class VisibilityShowIcon extends LitElement {
 			</d2l-icon-custom>
 		`;
 	}
+
 }
 
 customElements.define(VisibilityShowIcon.is, VisibilityShowIcon);

--- a/src/custom-icons/visibility-show.js
+++ b/src/custom-icons/visibility-show.js
@@ -1,5 +1,5 @@
-import { css, html, LitElement } from 'lit-element';
 import '@brightspace-ui/core/components/icons/icon-custom';
+import { css, html, LitElement } from 'lit-element';
 
 class VisibilityShowIcon extends LitElement {
 

--- a/src/diamond/diamond.js
+++ b/src/diamond/diamond.js
@@ -1,7 +1,6 @@
-import { LitElement, html } from 'lit-element';
+import { html, LitElement } from 'lit-element';
 
 class Diamond extends LitElement {
-	static get is() { return 'd2l-coa-diamond'; }
 
 	static get properties() {
 		return {
@@ -10,6 +9,8 @@ class Diamond extends LitElement {
 			width: { type: Number }
 		};
 	}
+
+	static get is() { return 'd2l-coa-diamond'; }
 
 	render() {
 		let computedEdgeWidth, computedWidth;
@@ -41,6 +42,7 @@ class Diamond extends LitElement {
 			</svg>
 		`;
 	}
+
 }
 
 customElements.define(Diamond.is, Diamond);

--- a/src/entities/AchievementScaleEntity.js
+++ b/src/entities/AchievementScaleEntity.js
@@ -1,5 +1,5 @@
-import { Entity } from 'siren-sdk/src/es6/Entity';
 import { AchievementLevelEntity } from './AchievementLevelEntity';
+import { Entity } from 'siren-sdk/src/es6/Entity';
 
 export class AchievementScaleEntity extends Entity {
 	onLevelChanged(onChange) {

--- a/src/entities/ClassOverallAchievementEntity.js
+++ b/src/entities/ClassOverallAchievementEntity.js
@@ -1,9 +1,9 @@
-import { Entity } from 'siren-sdk/src/es6/Entity';
-import { SelflessEntity } from 'siren-sdk/src/es6/SelflessEntity';
 import { AchievementScaleEntity } from './AchievementScaleEntity';
-import { CoaClasslistEntity } from './CoaClasslistEntity.js';
-import { OutcomeEntity } from './OutcomeEntity.js';
 import { CalculationMethodEntity } from './CalculationMethodEntity';
+import { CoaClasslistEntity } from './CoaClasslistEntity.js';
+import { Entity } from 'siren-sdk/src/es6/Entity';
+import { OutcomeEntity } from './OutcomeEntity.js';
+import { SelflessEntity } from 'siren-sdk/src/es6/SelflessEntity';
 
 class OutcomeClassProgressEntity extends SelflessEntity {
 

--- a/src/entities/CoaClasslistEntity.js
+++ b/src/entities/CoaClasslistEntity.js
@@ -1,6 +1,6 @@
 import { Entity } from 'siren-sdk/src/es6/Entity';
-import { SelflessEntity } from 'siren-sdk/src/es6/SelflessEntity';
 import { MasteryViewRowEntity } from './MasteryViewRowEntity';
+import { SelflessEntity } from 'siren-sdk/src/es6/SelflessEntity';
 import { UserEntity } from './UserEntity';
 import { UserProgressOutcomeCollectionEntity } from './UserProgressOutcomeCollectionEntity';
 

--- a/src/entities/DemonstrationEntity.js
+++ b/src/entities/DemonstrationEntity.js
@@ -1,7 +1,7 @@
-import { Entity } from 'siren-sdk/src/es6/Entity';
-import { SelflessEntity } from 'siren-sdk/src/es6/SelflessEntity';
 import { AchievementLevelEntity } from './AchievementLevelEntity';
+import { Entity } from 'siren-sdk/src/es6/Entity';
 import { FeedbackListEntity } from './FeedbackListEntity';
+import { SelflessEntity } from 'siren-sdk/src/es6/SelflessEntity';
 import { UserActivityUsageEntity } from './UserActivityUsageEntity';
 
 export class DemonstratableLevelEntity extends SelflessEntity {

--- a/src/entities/MasteryViewRowEntity.js
+++ b/src/entities/MasteryViewRowEntity.js
@@ -1,6 +1,6 @@
+import { DemonstrationEntity } from './DemonstrationEntity';
 import { Entity } from 'siren-sdk/src/es6/Entity';
 import { SelflessEntity } from 'siren-sdk/src/es6/SelflessEntity';
-import { DemonstrationEntity } from './DemonstrationEntity';
 
 class MasteryViewCellEntity extends SelflessEntity {
 

--- a/src/entities/OutcomeActivityCollectionEntity.js
+++ b/src/entities/OutcomeActivityCollectionEntity.js
@@ -1,5 +1,5 @@
-import { Entity } from 'siren-sdk/src/es6/Entity';
 import { AchievementScaleEntity } from './AchievementScaleEntity';
+import { Entity } from 'siren-sdk/src/es6/Entity';
 import { OutcomeActivityEntity } from './OutcomeActivityEntity';
 
 export class OutcomeActivityCollectionEntity extends Entity {

--- a/src/entities/OutcomeActivityEntity.js
+++ b/src/entities/OutcomeActivityEntity.js
@@ -1,5 +1,5 @@
-import { Entity } from 'siren-sdk/src/es6/Entity';
 import { DemonstrationEntity } from './DemonstrationEntity';
+import { Entity } from 'siren-sdk/src/es6/Entity';
 import { UserActivityUsageEntity } from './UserActivityUsageEntity';
 
 export class OutcomeActivityEntity extends Entity {

--- a/src/entities/UserProgressOutcomeEntity.js
+++ b/src/entities/UserProgressOutcomeEntity.js
@@ -1,6 +1,6 @@
 import { Entity } from 'siren-sdk/src/es6/Entity';
-import { OutcomeEntity } from './OutcomeEntity';
 import { OutcomeActivityCollectionEntity } from './OutcomeActivityCollectionEntity';
+import { OutcomeEntity } from './OutcomeEntity';
 
 export class UserProgressOutcomeEntity extends Entity {
 	static get class() { return 'user-progress-outcome'; }

--- a/src/mastery-view-table/mastery-view-outcome-header-cell.js
+++ b/src/mastery-view-table/mastery-view-outcome-header-cell.js
@@ -1,10 +1,9 @@
-import { html, css } from 'lit-element';
+import { css, html } from 'lit-element';
 import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/tooltip/tooltip.js';
 import { StackedBar } from '../stacked-bar/stacked-bar';
 
 export class MasteryViewOutcomeHeaderCell extends StackedBar {
-	static get is() { return 'd2l-mastery-view-outcome-header-cell'; }
 
 	static get properties() {
 		return {
@@ -162,6 +161,8 @@ export class MasteryViewOutcomeHeaderCell extends StackedBar {
 		this.tooltipAlign = '';
 	}
 
+	static get is() { return 'd2l-mastery-view-outcome-header-cell'; }
+
 	render() {
 		const outcomeLabel = this.outcomeName && this.outcomeName.length ? html`${this.outcomeName}. ` : null;
 		return html`
@@ -190,11 +191,11 @@ export class MasteryViewOutcomeHeaderCell extends StackedBar {
 	}
 
 	_getGraphLevelsLabel() {
-		var labelText = '';
+		let labelText = '';
 		this._histData.map((levelData) => {
 			const name = levelData.name;
 			const percentage = this._getLevelCountText(levelData);
-			labelText += this.localize('levelNamePercentLabel', 'name', name, 'percentage', percentage) + ' ';
+			labelText += `${this.localize('levelNamePercentLabel', 'name', name, 'percentage', percentage)} `;
 		});
 
 		return labelText;
@@ -233,6 +234,7 @@ export class MasteryViewOutcomeHeaderCell extends StackedBar {
 		</tr>
 		`;
 	}
+
 }
 
 customElements.define(MasteryViewOutcomeHeaderCell.is, MasteryViewOutcomeHeaderCell);

--- a/src/mastery-view-table/mastery-view-outcome-header-cell.js
+++ b/src/mastery-view-table/mastery-view-outcome-header-cell.js
@@ -1,6 +1,6 @@
-import { css, html } from 'lit-element';
 import '@brightspace-ui/core/components/colors/colors.js';
 import '@brightspace-ui/core/components/tooltip/tooltip.js';
+import { css, html } from 'lit-element';
 import { StackedBar } from '../stacked-bar/stacked-bar';
 
 export class MasteryViewOutcomeHeaderCell extends StackedBar {

--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -895,7 +895,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 						token=${this.token}
 						outcome-href=${outcomeData.href}
 						._logger="${this._logger}"
-					/>
+					></d2l-mastery-view-user-outcome-cell>
 				</td>
 			`)}
 		</tr>
@@ -933,7 +933,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 				tooltip-align="${tooltipAlign}"
 				display-unassessed
 				aria-label="${this.localize('outcomeInfo', 'name', outcomeData.name, 'description', outcomeData.description)}"
-			/>
+			></d2l-mastery-view-outcome-header-cell>
 		</th>`;
 
 	}
@@ -1019,7 +1019,8 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 							@click=${this._onPreviousPageButtonClicked}
 							aria-label=${this.localize('goToPreviousPage')}
 						>
-							<d2l-icon-left-arrow ?hidden=${!this._shouldShowPrevPageButton()} />
+							<d2l-icon-left-arrow ?hidden=${!this._shouldShowPrevPageButton()}>
+							</d2l-icon-left-arrow>
 						</d2l-button-subtle>
 					</td>
 					<td class="page-label-container">
@@ -1029,7 +1030,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 						<select
 							id="page-select-menu"
 							class="d2l-input-select"
-							@change=${this._onPageSelectDropdownSelectionChanged}}
+							@change=${this._onPageSelectDropdownSelectionChanged}
 							aria-label=${this.localize('selectTablePage')}
 							aria-controls="new-page-select-live-text"
 						>
@@ -1044,14 +1045,15 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 							@click=${this._onNextPageButtonClicked}
 							aria-label=${this.localize('goToNextPage')}
 						>
-							<d2l-icon-right-arrow ?hidden=${!this._shouldShowNextPageButton()} />
+							<d2l-icon-right-arrow ?hidden=${!this._shouldShowNextPageButton()}>
+							</d2l-icon-right-arrow>
 						</d2l-button-subtle>
 					</td>
 					<td class="page-size-menu-container">
 						<select
 							id="page-size-menu"
 							class="d2l-input-select"
-							@change=${this._onPageSizeDropdownSelectionChanged}}
+							@change=${this._onPageSizeDropdownSelectionChanged}
 							aria-label=${this.localize('selectLearnersPerPage')}
 							aria-controls="new-page-size-live-text"
 						>
@@ -1066,13 +1068,13 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 			id="new-page-select-live-text"
 			aria-live="polite"
 			aria-label=${this.localize('newPageSelectLiveText', 'pageNum', this._currentPage, 'totalPages', this._pageCount)}
-		/>
+		></div>
 		<div
 			role="region"
 			id="new-page-size-live-text"
 			aria-live="polite"
 			aria-label=${this.localize('newPageSizeLiveText', 'pageSize', this._rowsPerPage)}
-		/>
+		></div>
 		`;
 	}
 

--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -1,41 +1,35 @@
-import { css, html, LitElement } from 'lit-element';
-import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
-import { LocalizeMixin } from '../LocalizeMixin';
-import { TelemetryMixin } from '../TelemetryMixin';
-import { ClassOverallAchievementEntity } from '../entities/ClassOverallAchievementEntity.js';
-import './mastery-view-user-outcome-cell.js';
-import './mastery-view-outcome-header-cell.js';
-import { ifDefined } from 'lit-html/directives/if-defined';
-import { performSirenAction } from 'siren-sdk/src/es6/SirenAction.js';
-import { ErrorLogger } from '../ErrorLogger.js';
-
-import { d2lTableStyles } from '../custom-styles/d2l-table-styles';
-import { linkStyles } from '@brightspace-ui/core/components/link/link.js';
-import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
-import { announce } from '@brightspace-ui/core/helpers/announce.js';
-import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles';
-
-import '../custom-icons/LeftArrow.js';
-import '../custom-icons/RightArrow.js';
-
-import 'd2l-table/d2l-table.js';
-import 'd2l-table/d2l-scroll-wrapper.js';
-
-import '@brightspace-ui/core/components/alert/alert.js';
 import '@brightspace-ui/core/components/alert/alert-toast.js';
-import '@brightspace-ui/core/components/typography/typography.js';
-import '@brightspace-ui/core/components/button/button.js';
+import '@brightspace-ui/core/components/alert/alert.js';
 import '@brightspace-ui/core/components/button/button-subtle.js';
-import '@brightspace-ui/core/components/dialog/dialog-confirm.js';
+import '@brightspace-ui/core/components/button/button.js';
 import '@brightspace-ui/core/components/colors/colors.js';
+import '@brightspace-ui/core/components/dialog/dialog-confirm.js';
+import '@brightspace-ui/core/components/icons/icon.js';
 import '@brightspace-ui/core/components/inputs/input-checkbox.js';
 import '@brightspace-ui/core/components/inputs/input-search.js';
-import '@brightspace-ui/core/components/icons/icon.js';
-import '@brightspace-ui/core/components/link/link.js';
 import '@brightspace-ui/core/components/tooltip/tooltip.js';
-
-import Images from '../images/images.js';
+import '@brightspace-ui/core/components/typography/typography.js';
+import 'd2l-table/d2l-scroll-wrapper.js';
+import 'd2l-table/d2l-table.js';
+import '../custom-icons/LeftArrow.js';
+import '../custom-icons/RightArrow.js';
+import './mastery-view-outcome-header-cell.js';
+import './mastery-view-user-outcome-cell.js';
+import { css, html, LitElement } from 'lit-element';
+import { announce } from '@brightspace-ui/core/helpers/announce.js';
+import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles';
+import { ClassOverallAchievementEntity } from '../entities/ClassOverallAchievementEntity.js';
 import { Consts } from '../consts';
+import { d2lTableStyles } from '../custom-styles/d2l-table-styles';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
+import { ErrorLogger } from '../ErrorLogger.js';
+import { ifDefined } from 'lit-html/directives/if-defined';
+import Images from '../images/images.js';
+import { linkStyles } from '@brightspace-ui/core/components/link/link.js';
+import { LocalizeMixin } from '../LocalizeMixin';
+import { performSirenAction } from 'siren-sdk/src/es6/SirenAction.js';
+import { selectStyles } from '@brightspace-ui/core/components/inputs/input-select-styles.js';
+import { TelemetryMixin } from '../TelemetryMixin';
 
 const BULK_RELEASE_ACTION = 'release';
 const BULK_RETRACT_ACTION = 'retract';

--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { LocalizeMixin } from '../LocalizeMixin';
 import { TelemetryMixin } from '../TelemetryMixin';
@@ -61,7 +61,7 @@ const _getOutcomePrefix = function(outcome) {
 
 	if (outcome.label && outcome.label.trim()) {
 		if (outcome.listId && outcome.listId.trim()) {
-			return outcome.label.trim() + ' ' + outcome.listId.trim();
+			return `${outcome.label.trim()} ${outcome.listId.trim()}`;
 		}
 		return outcome.label.trim();
 	}
@@ -98,7 +98,6 @@ const _compareOutcomes = function(a, b) {
 };
 
 class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitElement))) {
-	static get is() { return 'd2l-mastery-view-table'; }
 
 	static get properties() {
 		return {
@@ -372,6 +371,8 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 		this._onResize = this._onResize.bind(this);
 	}
 
+	static get is() { return 'd2l-mastery-view-table'; }
+
 	connectedCallback() {
 		super.connectedCallback();
 
@@ -584,14 +585,14 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 			displayText = firstName;
 		}
 		else if (firstLastDisplay) {
-			displayText = firstName + ' ' + lastName;
+			displayText = `${firstName} ${lastName}`;
 		}
 		else {
-			displayText = lastName + ', ' + firstName;
+			displayText = `${lastName}, ${firstName}`;
 		}
 
 		if (firstName && lastName) {
-			ariaText = firstName + ' ' + lastName;
+			ariaText = `${firstName} ${lastName}`;
 		}
 		else {
 			ariaText = displayText;
@@ -606,7 +607,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 
 	_goToPageNumber(newPage) {
 		this._currentPage = newPage;
-		var selector = this.shadowRoot.getElementById('page-select-menu');
+		const selector = this.shadowRoot.getElementById('page-select-menu');
 		if (selector) {
 			selector.selectedIndex = newPage - 1;
 		}
@@ -754,13 +755,13 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 	}
 
 	_onPageSelectDropdownSelectionChanged() {
-		var selector = this.shadowRoot.getElementById('page-select-menu');
+		const selector = this.shadowRoot.getElementById('page-select-menu');
 		const newPageNumber = parseInt(selector.options[selector.selectedIndex].value);
 		this._goToPageNumber(newPageNumber);
 	}
 
 	_onPageSizeDropdownSelectionChanged() {
-		var selector = this.shadowRoot.getElementById('page-size-menu');
+		const selector = this.shadowRoot.getElementById('page-size-menu');
 		const newRowsPerPage = parseInt(selector.options[selector.selectedIndex].value);
 		this._rowsPerPage = newRowsPerPage;
 		this._updatePageCount();
@@ -875,7 +876,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 	_renderLearnerRow(learnerData, outcomeHeaderData) {
 		const userNameText = this._getUserNameText(learnerData.firstName, learnerData.lastName, this._nameFirstLastFormat);
 		if (outcomeHeaderData.length === 0 || !learnerData.rowDataHref) {
-			return this._renderNoLearnerState(this.localize('learnerHasNoData', 'username', learnerData.firstName + ' ' + learnerData.lastName));
+			return this._renderNoLearnerState(this.localize('learnerHasNoData', 'username', `${learnerData.firstName} ${learnerData.lastName}`));
 		}
 
 		return html`
@@ -995,7 +996,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 			return null;
 		}
 		const pageSelectOptionTemplates = [];
-		for (var i = 1; i <= this._pageCount; i++) {
+		for (let i = 1; i <= this._pageCount; i++) {
 			pageSelectOptionTemplates.push(html`
 				<option value=${i}>
 					${this.localize('pageSelectOptionText', 'currentPage', i, 'pageCount', this._pageCount)}
@@ -1160,10 +1161,10 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 				? bodyWidth - (bodyWidth * 0.02439 * 2)
 				: bodyWidth - 60;
 			if (header) {
-				header.style.width = bodyWidth + 'px';
+				header.style.width = `${bodyWidth}px`;
 			}
 			containers.forEach((container) => {
-				container.style.width = containerWidth + 'px';
+				container.style.width = `${containerWidth}px`;
 			});
 		});
 	}
@@ -1187,12 +1188,12 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 			const rightLast = right.lastName || '';
 
 			if (byLastName) {
-				leftSortString = leftLast + '_' + leftFirst;
-				rightSortString = rightLast + '_' + rightFirst;
+				leftSortString = `${leftLast}_${leftFirst}`;
+				rightSortString = `${rightLast}_${rightFirst}`;
 			}
 			else {
-				leftSortString = leftFirst + '_' + leftLast;
-				rightSortString = rightFirst + '_' + rightLast;
+				leftSortString = `${leftFirst}_${leftLast}`;
+				rightSortString = `${rightFirst}_${rightLast}`;
 			}
 
 			if (descending) {

--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -894,7 +894,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 						href=${learnerData.rowDataHref}
 						token=${this.token}
 						outcome-href=${outcomeData.href}
-						._logger="${this._logger}"
+						.logger="${this._logger}"
 					></d2l-mastery-view-user-outcome-cell>
 				</td>
 			`)}

--- a/src/mastery-view-table/mastery-view-user-outcome-cell.js
+++ b/src/mastery-view-table/mastery-view-user-outcome-cell.js
@@ -159,7 +159,7 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 					tabindex="0"
 					aria-label="${this._getAriaText(null)}"
 				>
-					<div class="assessment-label-skeleton d2l-skeletize" />
+					<div class="assessment-label-skeleton d2l-skeletize"></div>
 				</div>
 			`;
 		}
@@ -196,11 +196,11 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 				aria-hidden="true"
 				title="${data.published ? this.localize('published') : this.localize('notPublished')}"
 			>
-				${data.published ? html`<d2l-icon-visibility-show />` : html`<d2l-icon-visibility-hide />`}
+				${data.published ? html`<d2l-icon-visibility-show></d2l-icon-visibility-show>` : html`<d2l-icon-visibility-hide></d2l-icon-visibility-hide>`}
 			</div>
 			${data.outdated ? html`
 				<span aria-hidden="true" title="${this.localize('outOfDate')}">
-					<d2l-icon class="assessment-outdated-icon" icon="tier1:refresh" />
+					<d2l-icon class="assessment-outdated-icon" icon="tier1:refresh"></d2l-icon>
 				</span>
 			` : null}
 

--- a/src/mastery-view-table/mastery-view-user-outcome-cell.js
+++ b/src/mastery-view-table/mastery-view-user-outcome-cell.js
@@ -1,17 +1,17 @@
-import { css, html, LitElement } from 'lit-element';
-import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
-import { LocalizeMixin } from '../LocalizeMixin';
-import { TelemetryMixin } from '../TelemetryMixin';
-import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
-import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles';
 import '@brightspace-ui/core/components/colors/colors';
 import '@brightspace-ui/core/components/tooltip/tooltip';
 import 'd2l-table/d2l-table.js';
-import { MasteryViewRowEntity } from '../entities/MasteryViewRowEntity';
 import '../custom-icons/visibility-hide.js';
 import '../custom-icons/visibility-show.js';
+import { css, html, LitElement } from 'lit-element';
+import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/styles';
 import { Consts } from '../consts';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { ErrorLogger } from '../ErrorLogger.js';
+import { LocalizeMixin } from '../LocalizeMixin';
+import { MasteryViewRowEntity } from '../entities/MasteryViewRowEntity';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
+import { TelemetryMixin } from '../TelemetryMixin';
 
 const KEYCODES = {
 	ENTER: 13,

--- a/src/mastery-view-table/mastery-view-user-outcome-cell.js
+++ b/src/mastery-view-table/mastery-view-user-outcome-cell.js
@@ -26,8 +26,8 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 				attribute: 'outcome-href',
 				type: String
 			},
-			_cellData: Object,
-			_logger: ErrorLogger
+			logger: ErrorLogger,
+			_cellData: Object
 		};
 	}
 
@@ -171,8 +171,8 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 			class="cell-content-container"
 			tabindex="0"
 			style="background-color:${data.levelColor}"
-			@click=${() => { this._onClick(); }}
-			@keydown=${(e) => { this._onKeyDown(e); }}
+			@click=${this._onClick}
+			@keydown=${this._onKeyDown}
 			aria-label="${this._getAriaText(data)}"
 		>
 			<div id="assessment-fraction-container" aria-hidden="true">
@@ -266,7 +266,7 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 
 	_onEntityChanged(entity, error) {
 		if (!entity) {
-			this._logger.logSirenError(this.href, 'GET', error);
+			this.logger.logSirenError(this.href, 'GET', error);
 			return;
 		}
 
@@ -294,7 +294,7 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 					name = loa.getName();
 					color = loa.getColor();
 				}, error => {
-					this._logger.logSirenError(demonstratedLevel._levelHref(), 'GET', error);
+					this.logger.logSirenError(demonstratedLevel._levelHref(), 'GET', error);
 				});
 			}
 			demonstration.subEntitiesLoaded().then(() => {
@@ -312,7 +312,7 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 		}, error => {
 			const demonstration = cellEntity._getCheckpointDemonstration() || {};
 			const href = (demonstration && demonstration.getSelfHref) ? demonstration.getSelfHref() : null;
-			this._logger.logSirenError(href, 'GET', error);
+			this.logger.logSirenError(href, 'GET', error);
 		});
 
 		entity.subEntitiesLoaded().then(() => {

--- a/src/mastery-view-table/mastery-view-user-outcome-cell.js
+++ b/src/mastery-view-table/mastery-view-user-outcome-cell.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { LocalizeMixin } from '../LocalizeMixin';
 import { TelemetryMixin } from '../TelemetryMixin';
@@ -19,7 +19,6 @@ const KEYCODES = {
 };
 
 export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(EntityMixinLit(TelemetryMixin(LitElement)))) {
-	static get is() { return 'd2l-mastery-view-user-outcome-cell'; }
 
 	static get properties() {
 		return {
@@ -150,6 +149,8 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 		this._setEntityType(MasteryViewRowEntity);
 	}
 
+	static get is() { return 'd2l-mastery-view-user-outcome-cell'; }
+
 	render() {
 		if (this.skeleton) {
 			return html`
@@ -219,7 +220,7 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 			return this.localize('loadingOverallAchievement');
 		}
 
-		var assessmentInfo = '';
+		let assessmentInfo = '';
 		if (data.levelName === Consts.noCoaLevelName) {
 			assessmentInfo += this.localize('notEvaluated') + this.localize('commaSeparator');
 		}
@@ -339,6 +340,7 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 			this._onClick();
 		}
 	}
+
 }
 
 customElements.define(MasteryViewUserOutcomeCell.is, MasteryViewUserOutcomeCell);

--- a/src/outcome-text-display/outcome-text-display.js
+++ b/src/outcome-text-display/outcome-text-display.js
@@ -1,15 +1,12 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { LocalizeMixin } from '../LocalizeMixin';
-import { heading3Styles, bodySmallStyles } from '@brightspace-ui/core/components/typography/styles';
+import { bodySmallStyles, heading3Styles } from '@brightspace-ui/core/components/typography/styles';
 import { OutcomeEntity } from '../entities/OutcomeEntity';
 import './outcome-text-skeleton.js';
 
 class OutcomeTextDisplay extends SkeletonMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
-	static get is() {
-		return 'd2l-coa-outcome-text-display';
-	}
 
 	static get properties() {
 		return {
@@ -41,6 +38,8 @@ class OutcomeTextDisplay extends SkeletonMixin(EntityMixinLit(LocalizeMixin(LitE
 		this.skeleton = true;
 	}
 
+	static get is() { return 'd2l-coa-outcome-text-display'; }
+
 	render() {
 		return this.skeleton ? html`
 			<d2l-coa-outcome-text-skeleton>
@@ -65,6 +64,7 @@ class OutcomeTextDisplay extends SkeletonMixin(EntityMixinLit(LocalizeMixin(LitE
 			this.skeleton = false;
 		}
 	}
+
 }
 
 customElements.define(OutcomeTextDisplay.is, OutcomeTextDisplay);

--- a/src/outcome-text-display/outcome-text-display.js
+++ b/src/outcome-text-display/outcome-text-display.js
@@ -1,10 +1,10 @@
+import './outcome-text-skeleton.js';
+import { bodySmallStyles, heading3Styles } from '@brightspace-ui/core/components/typography/styles';
 import { css, html, LitElement } from 'lit-element';
-import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { LocalizeMixin } from '../LocalizeMixin';
-import { bodySmallStyles, heading3Styles } from '@brightspace-ui/core/components/typography/styles';
 import { OutcomeEntity } from '../entities/OutcomeEntity';
-import './outcome-text-skeleton.js';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
 class OutcomeTextDisplay extends SkeletonMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
 

--- a/src/outcome-text-display/outcome-text-skeleton.js
+++ b/src/outcome-text-display/outcome-text-skeleton.js
@@ -1,7 +1,7 @@
+import '@brightspace-ui/core/components/colors/colors';
+import { bodySmallStyles, heading3Styles } from '@brightspace-ui/core/components/typography/styles';
 import { css, html, LitElement } from 'lit-element';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
-import { bodySmallStyles, heading3Styles } from '@brightspace-ui/core/components/typography/styles';
-import '@brightspace-ui/core/components/colors/colors';
 
 export class OutcomeTextSkeleton extends SkeletonMixin(LitElement) {
 

--- a/src/outcome-text-display/outcome-text-skeleton.js
+++ b/src/outcome-text-display/outcome-text-skeleton.js
@@ -1,13 +1,9 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
-import { heading3Styles, bodySmallStyles } from '@brightspace-ui/core/components/typography/styles';
+import { bodySmallStyles, heading3Styles } from '@brightspace-ui/core/components/typography/styles';
 import '@brightspace-ui/core/components/colors/colors';
 
 export class OutcomeTextSkeleton extends SkeletonMixin(LitElement) {
-
-	static get is() {
-		return 'd2l-coa-outcome-text-skeleton';
-	}
 
 	static get properties() {
 		return {};
@@ -39,12 +35,15 @@ export class OutcomeTextSkeleton extends SkeletonMixin(LitElement) {
 		this.skeleton = true;
 	}
 
+	static get is() { return 'd2l-coa-outcome-text-skeleton'; }
+
 	render() {
 		return html`
 			<p id="outcome-text-skeleton" class="d2l-heading-3 d2l-skeletize-paragraph-2">2-line</p>
 			<p id="outcome-level-skeleton" class="d2l-body-small d2l-skeletize">1-line</p>
 		`;
 	}
+
 }
 
 customElements.define(OutcomeTextSkeleton.is, OutcomeTextSkeleton);

--- a/src/overall-achievement-tile/overall-achievement-skeleton.js
+++ b/src/overall-achievement-tile/overall-achievement-skeleton.js
@@ -1,6 +1,6 @@
+import '@brightspace-ui/core/components/colors/colors';
 import { css, html, LitElement } from 'lit-element';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
-import '@brightspace-ui/core/components/colors/colors';
 
 export class OverallAchievementSkeleton extends SkeletonMixin(LitElement) {
 

--- a/src/overall-achievement-tile/overall-achievement-skeleton.js
+++ b/src/overall-achievement-tile/overall-achievement-skeleton.js
@@ -1,12 +1,8 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import '@brightspace-ui/core/components/colors/colors';
 
 export class OverallAchievementSkeleton extends SkeletonMixin(LitElement) {
-
-	static get is() {
-		return 'd2l-coa-overall-achievement-skeleton';
-	}
 
 	static get properties() {
 		return {};
@@ -28,11 +24,14 @@ export class OverallAchievementSkeleton extends SkeletonMixin(LitElement) {
 		this.skeleton = true;
 	}
 
+	static get is() { return 'd2l-coa-overall-achievement-skeleton'; }
+
 	render() {
 		return html`
             <div class="d2l-skeletize"></div>
 		`;
 	}
+
 }
 
 customElements.define(OverallAchievementSkeleton.is, OverallAchievementSkeleton);

--- a/src/overall-achievement-tile/overall-achievement-tile.js
+++ b/src/overall-achievement-tile/overall-achievement-tile.js
@@ -1,11 +1,3 @@
-import { css, html, LitElement } from 'lit-element';
-import { unsafeHTML } from 'lit-html/directives/unsafe-html';
-import { bodySmallStyles, heading4Styles } from '@brightspace-ui/core/components/typography/styles';
-import { formatDate } from '@brightspace-ui/intl/lib/dateTime.js';
-import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
-import { LocalizeMixin } from '../LocalizeMixin';
-import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
-import { OutcomeActivityEntity } from '../entities/OutcomeActivityEntity';
 import '@brightspace-ui/core/components/colors/colors';
 import '@brightspace-ui/core/components/icons/icon';
 import '@brightspace-ui/core/components/icons/icon-custom';
@@ -16,6 +8,14 @@ import '../custom-icons/quote';
 import '../custom-icons/visibility-hide';
 import '../custom-icons/visibility-show';
 import './overall-achievement-skeleton';
+import { bodySmallStyles, heading4Styles } from '@brightspace-ui/core/components/typography/styles';
+import { css, html, LitElement } from 'lit-element';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
+import { formatDate } from '@brightspace-ui/intl/lib/dateTime.js';
+import { LocalizeMixin } from '../LocalizeMixin';
+import { OutcomeActivityEntity } from '../entities/OutcomeActivityEntity';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
+import { unsafeHTML } from 'lit-html/directives/unsafe-html';
 
 class OverallAchievementTile extends SkeletonMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
 

--- a/src/overall-achievement-tile/overall-achievement-tile.js
+++ b/src/overall-achievement-tile/overall-achievement-tile.js
@@ -1,6 +1,6 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import { unsafeHTML } from 'lit-html/directives/unsafe-html';
-import { heading4Styles, bodySmallStyles } from '@brightspace-ui/core/components/typography/styles';
+import { bodySmallStyles, heading4Styles } from '@brightspace-ui/core/components/typography/styles';
 import { formatDate } from '@brightspace-ui/intl/lib/dateTime.js';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { LocalizeMixin } from '../LocalizeMixin';
@@ -18,9 +18,6 @@ import '../custom-icons/visibility-show';
 import './overall-achievement-skeleton';
 
 class OverallAchievementTile extends SkeletonMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
-	static get is() {
-		return 'd2l-coa-overall-achievement-tile';
-	}
 
 	static get properties() {
 		return {
@@ -149,6 +146,8 @@ class OverallAchievementTile extends SkeletonMixin(EntityMixinLit(LocalizeMixin(
 		this.skeleton = true;
 	}
 
+	static get is() { return 'd2l-coa-overall-achievement-tile'; }
+
 	render() {
 		const dateElement = this._accessDate && html`
 			<div id="date" class="d2l-body-small">${formatDate(this._accessDate, { format: 'short' })}</div>
@@ -256,6 +255,7 @@ class OverallAchievementTile extends SkeletonMixin(EntityMixinLit(LocalizeMixin(
 			<d2l-icon-visibility-hide id="visibility-icon"></d2l-icon-visibility-hide>
 		`;
 	}
+
 }
 
 customElements.define(OverallAchievementTile.is, OverallAchievementTile);

--- a/src/primary-panel/primary-panel.js
+++ b/src/primary-panel/primary-panel.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { LocalizeMixin } from '../LocalizeMixin';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
@@ -16,9 +16,6 @@ import { UserProgressOutcomeEntity } from '../entities/UserProgressOutcomeEntity
 import { Consts } from '../consts';
 
 class PrimaryPanel extends SkeletonMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
-	static get is() {
-		return 'd2l-coa-primary-panel';
-	}
 
 	static get properties() {
 		return {
@@ -88,6 +85,8 @@ class PrimaryPanel extends SkeletonMixin(EntityMixinLit(LocalizeMixin(LitElement
 		this._checkpointHref = '';
 		this._checkpointPublished = false;
 	}
+
+	static get is() { return 'd2l-coa-primary-panel'; }
 
 	render() {
 
@@ -234,6 +233,7 @@ class PrimaryPanel extends SkeletonMixin(EntityMixinLit(LocalizeMixin(LitElement
 			});
 		}
 	}
+
 }
 
 customElements.define(PrimaryPanel.is, PrimaryPanel);

--- a/src/primary-panel/primary-panel.js
+++ b/src/primary-panel/primary-panel.js
@@ -1,8 +1,3 @@
-import { css, html, LitElement } from 'lit-element';
-import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
-import { LocalizeMixin } from '../LocalizeMixin';
-import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
-import { heading3Styles } from '@brightspace-ui/core/components/typography/styles';
 import '@brightspace-ui/core/components/button/button-icon';
 import '../outcome-text-display/outcome-text-display';
 import '../outcome-text-display/outcome-text-skeleton';
@@ -12,8 +7,13 @@ import '../assessment-summary/assessment-summary';
 import '../assessment-list/assessment-list';
 import '../trend/big-trend';
 import '../trend/big-trend-skeleton';
-import { UserProgressOutcomeEntity } from '../entities/UserProgressOutcomeEntity';
+import { css, html, LitElement } from 'lit-element';
 import { Consts } from '../consts';
+import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
+import { heading3Styles } from '@brightspace-ui/core/components/typography/styles';
+import { LocalizeMixin } from '../LocalizeMixin';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
+import { UserProgressOutcomeEntity } from '../entities/UserProgressOutcomeEntity';
 
 class PrimaryPanel extends SkeletonMixin(EntityMixinLit(LocalizeMixin(LitElement))) {
 

--- a/src/stacked-bar/stacked-bar.js
+++ b/src/stacked-bar/stacked-bar.js
@@ -1,10 +1,10 @@
+import '@brightspace-ui/core/components/colors/colors.js';
+import '@brightspace-ui/core/components/tooltip/tooltip.js';
 import { css, html, LitElement } from 'lit-element';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { LocalizeMixin } from '../LocalizeMixin';
-import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import { OutcomeActivityCollectionEntity } from '../entities/OutcomeActivityCollectionEntity';
-import '@brightspace-ui/core/components/colors/colors.js';
-import '@brightspace-ui/core/components/tooltip/tooltip.js';
+import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 
 const unassessedColor = '#9ea5a9';
 

--- a/src/stacked-bar/stacked-bar.js
+++ b/src/stacked-bar/stacked-bar.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { LocalizeMixin } from '../LocalizeMixin';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
@@ -9,7 +9,6 @@ import '@brightspace-ui/core/components/tooltip/tooltip.js';
 const unassessedColor = '#9ea5a9';
 
 export class StackedBar extends SkeletonMixin(LocalizeMixin(EntityMixinLit(LitElement))) {
-	static get is() { return 'd2l-coa-stacked-bar'; }
 
 	static get properties() {
 		return {
@@ -152,6 +151,8 @@ export class StackedBar extends SkeletonMixin(LocalizeMixin(EntityMixinLit(LitEl
 		this._assessedCount = 0;
 		this.skeleton = true;
 	}
+
+	static get is() { return 'd2l-coa-stacked-bar'; }
 
 	render() {
 		return html`
@@ -301,6 +302,7 @@ export class StackedBar extends SkeletonMixin(LocalizeMixin(EntityMixinLit(LitEl
 			<div>${levelData.name}: ${this._getLevelCountText(levelData)}</div>
 		`;
 	}
+
 }
 
 customElements.define(StackedBar.is, StackedBar);

--- a/src/stacked-bar/stacked-bar.js
+++ b/src/stacked-bar/stacked-bar.js
@@ -272,7 +272,7 @@ export class StackedBar extends SkeletonMixin(LocalizeMixin(EntityMixinLit(LitEl
 	_renderGraph() {
 		if (this.skeleton) {
 			return html`
-				<div class="graph-bar-skeleton d2l-skeletize" />
+				<div class="graph-bar-skeleton d2l-skeletize"></div>
 			`;
 		}
 

--- a/src/trend/big-trend-skeleton.js
+++ b/src/trend/big-trend-skeleton.js
@@ -1,12 +1,8 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
 import '@brightspace-ui/core/components/colors/colors';
 
 export class BigTrendSkeleton extends SkeletonMixin(LitElement) {
-
-	static get is() {
-		return 'd2l-coa-big-trend-skeleton';
-	}
 
 	static get properties() {
 		return {};
@@ -28,11 +24,14 @@ export class BigTrendSkeleton extends SkeletonMixin(LitElement) {
 		this.skeleton = true;
 	}
 
+	static get is() { return 'd2l-coa-big-trend-skeleton'; }
+
 	render() {
 		return html`
             <div class="d2l-skeletize"></div>
 		`;
 	}
+
 }
 
 customElements.define(BigTrendSkeleton.is, BigTrendSkeleton);

--- a/src/trend/big-trend-skeleton.js
+++ b/src/trend/big-trend-skeleton.js
@@ -1,6 +1,6 @@
+import '@brightspace-ui/core/components/colors/colors';
 import { css, html, LitElement } from 'lit-element';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
-import '@brightspace-ui/core/components/colors/colors';
 
 export class BigTrendSkeleton extends SkeletonMixin(LitElement) {
 

--- a/src/trend/big-trend.js
+++ b/src/trend/big-trend.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import { LocalizeMixin } from '../LocalizeMixin';
 import { TrendMixin } from './TrendMixin';
 import '@brightspace-ui/core/components/colors/colors';
@@ -24,8 +24,6 @@ const BarTypes = Object.freeze({
 });
 
 class BigTrend extends TrendMixin(LocalizeMixin(LitElement)) {
-
-	static get is() { return 'd2l-coa-big-trend'; }
 
 	static get properties() {
 		return {
@@ -280,6 +278,8 @@ class BigTrend extends TrendMixin(LocalizeMixin(LitElement)) {
 		super();
 		this.instructor = false;
 	}
+
+	static get is() { return 'd2l-coa-big-trend'; }
 
 	firstUpdated() {
 		this.scrollContainer = this.renderRoot.getElementById('scroll');
@@ -787,6 +787,7 @@ class BigTrend extends TrendMixin(LocalizeMixin(LitElement)) {
 
 		this.scrollContainer.scrollLeft = scrollMax * (this._isRtl() ? -1 : 1);
 	}
+
 }
 
 customElements.define(BigTrend.is, BigTrend);

--- a/src/trend/big-trend.js
+++ b/src/trend/big-trend.js
@@ -395,8 +395,7 @@ class BigTrend extends TrendMixin(LocalizeMixin(LitElement)) {
 		const levels = trendData.levels;
 		const maxLevel = this._getMaxLevelScore(levels);
 		const gridHeight = rowHeight - GRID_THICKNESS;
-
-		const gridData = Array.apply(null, { length: maxLevel + 1 }).map((v, i) => {
+		const gridData = Array(...new Array(maxLevel + 1)).map((v, i) => {
 			return {
 				size: (i === maxLevel
 					? FOOTER_HEIGHT

--- a/src/trend/big-trend.js
+++ b/src/trend/big-trend.js
@@ -1,12 +1,12 @@
-import { css, html, LitElement } from 'lit-element';
-import { LocalizeMixin } from '../LocalizeMixin';
-import { TrendMixin } from './TrendMixin';
 import '@brightspace-ui/core/components/colors/colors';
 import '@brightspace-ui/core/components/icons/icon';
 import '@brightspace-ui/core/components/tooltip/tooltip';
-import { formatDate } from '@brightspace-ui/intl/lib/dateTime.js';
-import { ResizeObserver } from 'd2l-resize-aware/resize-observer-module';
 import './big-trend-skeleton';
+import { css, html, LitElement } from 'lit-element';
+import { formatDate } from '@brightspace-ui/intl/lib/dateTime.js';
+import { LocalizeMixin } from '../LocalizeMixin';
+import { ResizeObserver } from 'd2l-resize-aware/resize-observer-module';
+import { TrendMixin } from './TrendMixin';
 
 const COMPONENT_HEIGHT = 120;
 const DIAMOND_SIZE = 18;

--- a/src/trend/mini-trend.js
+++ b/src/trend/mini-trend.js
@@ -1,9 +1,9 @@
-import { css, html, LitElement } from 'lit-element';
-import { LocalizeMixin } from '../LocalizeMixin';
-import { TrendMixin } from './TrendMixin';
-import { bodySmallStyles } from '@brightspace-ui/core/components/typography/styles';
 import '@brightspace-ui/core/components/colors/colors';
 import '@brightspace-ui/core/components/tooltip/tooltip';
+import { css, html, LitElement } from 'lit-element';
+import { bodySmallStyles } from '@brightspace-ui/core/components/typography/styles';
+import { LocalizeMixin } from '../LocalizeMixin';
+import { TrendMixin } from './TrendMixin';
 
 const BLOCK_SPACING = 2;
 const COMPONENT_HEIGHT = 36;

--- a/src/trend/mini-trend.js
+++ b/src/trend/mini-trend.js
@@ -1,4 +1,4 @@
-import { LitElement, html, css } from 'lit-element';
+import { css, html, LitElement } from 'lit-element';
 import { LocalizeMixin } from '../LocalizeMixin';
 import { TrendMixin } from './TrendMixin';
 import { bodySmallStyles } from '@brightspace-ui/core/components/typography/styles';
@@ -19,7 +19,6 @@ const BarTypes = Object.freeze({
 });
 
 class MiniTrend extends TrendMixin(LocalizeMixin(LitElement)) {
-	static get is() { return 'd2l-coa-mini-trend'; }
 
 	static get styles() {
 		return [
@@ -128,6 +127,8 @@ class MiniTrend extends TrendMixin(LocalizeMixin(LitElement)) {
 			super.styles
 		];
 	}
+
+	static get is() { return 'd2l-coa-mini-trend'; }
 
 	render() {
 		const trendDataTruncated = this._truncTrendData(this._trendData);


### PR DESCRIPTION
This switches to using the lit config for eslint instead of the polymer 3 config. This required some manual fixes (sorting of imports, html fixes, js fixes). I've broken the commits up so they are easier to see individually by error type fixed. The code resorting is all from the automatic fixing stuff in eslint.