### PR TITLE
using color variable instead of table variable

### DIFF
--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -213,7 +213,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 
 				#no-learners-cell {
 					border-radius: 0;
-					border-bottom: 1px solid var(--d2l-table-border-color);
+					border-bottom: 1px solid var(--d2l-color-mica);
 				}
 
 				.no-learners-label {


### PR DESCRIPTION
The Polymer version of table currently exposes all of its CSS variables globally on the HTML element:
https://github.com/BrightspaceUI/table/blob/master/d2l-table-shared-styles.js

This isn't something we normally do or like doing, since typically the variables are meant for the component itself. I'd also like to remove and simplify a lot of these variables while porting this to Lit.

So this change replaces a usage of the variables with the underlying color variable used by table.