### PR TITLE
US127502 - Allow Removal of Ratio

### DIFF
--- a/demo/data/mastery-view-table/demonstrations/dem-lvl2-override.json
+++ b/demo/data/mastery-view-table/demonstrations/dem-lvl2-override.json
@@ -8,7 +8,7 @@
     "item"
   ],
   "properties": {
-    "dateAssessed": "2020-04-09T12:51:00.623Z"
+    "dateAssessed": "2020-06-09T12:51:00.623Z"
   },
   "entities": [
     {
@@ -33,27 +33,27 @@
     {
       "class": [
         "demonstratable-level",
-        "selected",
         "suggested"
       ],
       "rel": [
         "item"
       ],
       "properties": {
-        "levelId": "level1-long-name"
+        "levelId": "level1"
       },
       "links": [
         {
           "rel": [
             "https://achievements.api.brightspace.com/rels/level"
           ],
-          "href": "data/levels/level1-long-name.json"
+          "href": "data/levels/level1.json"
         }
       ]
     },
     {
       "class": [
-        "demonstratable-level"
+        "demonstratable-level",
+        "selected"
       ],
       "rel": [
         "item"
@@ -76,7 +76,7 @@
       "rel": [
         "self"
       ],
-      "href": "data/mastery-view-table/demonstrations/dem-lvl2-longname-override-olddate.json"
+      "href": "data/mastery-view-table/demonstrations/dem-lvl3-override.json"
     }
   ]
 }

--- a/demo/data/mastery-view-table/demonstrations/dem-lvl3-override.json
+++ b/demo/data/mastery-view-table/demonstrations/dem-lvl3-override.json
@@ -49,6 +49,26 @@
           "href": "data/levels/level1.json"
         }
       ]
+    },
+    {
+      "class": [
+        "demonstratable-level",
+        "selected"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "levelId": "level2"
+      },
+      "links": [
+        {
+          "rel": [
+            "https://achievements.api.brightspace.com/rels/level"
+          ],
+          "href": "data/levels/level2.json"
+        }
+      ]
     }
   ],
   "links": [

--- a/demo/data/mastery-view-table/demonstrations/dem-lvl3-override.json
+++ b/demo/data/mastery-view-table/demonstrations/dem-lvl3-override.json
@@ -1,7 +1,8 @@
 {
   "class": [
     "demonstration",
-    "assessed"
+    "assessed",
+    "mastery-override"
   ],
   "rel": [
     "item"
@@ -46,26 +47,6 @@
             "https://achievements.api.brightspace.com/rels/level"
           ],
           "href": "data/levels/level1.json"
-        }
-      ]
-    },
-    {
-      "class": [
-        "demonstratable-level",
-        "selected"
-      ],
-      "rel": [
-        "item"
-      ],
-      "properties": {
-        "levelId": "level2"
-      },
-      "links": [
-        {
-          "rel": [
-            "https://achievements.api.brightspace.com/rels/level"
-          ],
-          "href": "data/levels/level2.json"
         }
       ]
     }

--- a/demo/data/mastery-view-table/demonstrations/dem-lvl3-published-override.json
+++ b/demo/data/mastery-view-table/demonstrations/dem-lvl3-published-override.json
@@ -2,7 +2,8 @@
     "class": [
         "demonstration",
         "assessed",
-        "published"
+        "published",
+        "mastery-override"
     ],
     "rel": [
         "item"

--- a/demo/data/mastery-view-table/row-data/cell-demo-row.json
+++ b/demo/data/mastery-view-table/row-data/cell-demo-row.json
@@ -174,6 +174,65 @@
           "href": "about:blank"
         }
       ]
+    },
+    {
+      "class": [
+        "mastery-view-cell"
+      ],
+      "rel": [
+        "item"
+      ],
+      "entities": [],
+      "links": [
+        {
+          "rel": [
+            "https://outcomes.api.brightspace.com/rels/outcome"
+          ],
+          "href": "data/outcomes/o5.json"
+        },
+        {
+          "rel": [
+            "checkpoint-consistent-evaluation"
+          ],
+          "href": "about:blank"
+        }
+      ]
+    },
+    {
+      "class": [
+        "mastery-view-cell"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "ActivityCount": 3,
+        "AssessedActivityCount": 0,
+        "IsOutdated": false
+      },
+      "entities": [
+        {
+          "rel": [
+            "item",
+            "checkpoint-demonstration"
+          ],
+          "href": "data/mastery-view-table/demonstrations/dem-lvl2-override.json"
+        }
+      ],
+      "links": [
+        {
+          "rel": [
+            "https://outcomes.api.brightspace.com/rels/outcome"
+          ],
+          "href": "data/outcomes/o6.json"
+        },
+        {
+          "rel": [
+            "checkpoint-consistent-evaluation"
+          ],
+          "href": "about:blank"
+        }
+      ]
     }
   ],
   "links": [

--- a/demo/mastery-view-user-outcome-cell.html
+++ b/demo/mastery-view-user-outcome-cell.html
@@ -47,6 +47,16 @@
 				></d2l-mastery-view-user-outcome-cell>
 			</div>
 		</d2l-demo-snippet>
+		<h3>Level 3, published, override</h3>
+		<d2l-demo-snippet>
+			<div style="width: 9.9rem; height: 3rem; border: 1px solid var(--d2l-table-border-color);">
+				<d2l-mastery-view-user-outcome-cell
+					href="data/mastery-view-table/row-data/cell-demo-row.json"
+					token="abc123"
+					outcome-href="data/outcomes/o6.json"
+				></d2l-mastery-view-user-outcome-cell>
+			</div>
+		</d2l-demo-snippet>
 		<h3>Long level name, override, outdated</h3>
 		<d2l-demo-snippet>
 			<div style="width: 9.9rem; height: 3rem; border: 1px solid var(--d2l-table-border-color);">
@@ -64,6 +74,16 @@
 					href="data/mastery-view-table/row-data/cell-demo-row.json"
 					token="abc123"
 					outcome-href="data/outcomes/o4.json"
+				></d2l-mastery-view-user-outcome-cell>
+			</div>
+		</d2l-demo-snippet>
+		<h3>No overall assessment (ratio hidden)</h3>
+		<d2l-demo-snippet>
+			<div style="width: 9.9rem; height: 3rem; border: 1px solid var(--d2l-table-border-color);">
+				<d2l-mastery-view-user-outcome-cell
+					href="data/mastery-view-table/row-data/cell-demo-row.json"
+					token="abc123"
+					outcome-href="data/outcomes/o5.json"
 				></d2l-mastery-view-user-outcome-cell>
 			</div>
 		</d2l-demo-snippet>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.59",
+  "version": "1.1.60",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.59",
+  "version": "1.1.60",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "repository": "https://github.com/Brightspace/d2l-outcomes-overall-achievement.git",
   "scripts": {

--- a/src/mastery-view-table/mastery-view-user-outcome-cell.js
+++ b/src/mastery-view-table/mastery-view-user-outcome-cell.js
@@ -49,45 +49,41 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 				}
 
 				#assessment-fraction-container {
-					line-height: 0.6rem;
+					position: relative;
 				}
 
 				#assessment-fraction {
-					display: inline-block;
-					padding-left: 0.3rem;
-					padding-top: 0.3rem;
-					padding-right: 0.3rem;
+					position: absolute;
 					font-family: 'Lato', sans-serif;
 					font-size: 0.6rem;
-					color: var(--d2l-color-tungsten)
+					color: var(--d2l-color-tungsten);
+					line-height: 1.25rem;
+					padding-left: 0.3rem;
 				}
 
 				.assessment-label-container {
-					display: inline-block;
-					padding-left: 1.5rem;
-					padding-bottom: 0.4rem;
+					display: flex;
+					align-items:center;
 				}
 
-				:host([dir="rtl"]) .assessment-label-container {
-					padding-right: 1.5rem;
+				:host([dir="rtl"]) #assessment-fraction {
+					padding-right: 0.3rem;
 					padding-left: 0;
 				}
 
 				.assessment-level-label {
-					float: left;
 					white-space: nowrap;
 					overflow: hidden;
 					text-overflow: ellipsis;
 					max-width: 5rem;
-					line-height: 1.2rem;
+					display: block;
 				}
 
 				.assessment-label-skeleton {
 					width: 4.8rem;
 					height: 1rem;
 					margin-left: 1.5rem;
-					margin-top: 1rem;
-					float: left;
+					margin-right: 1.5rem;
 				}
 
 				.d2l-skeletize {
@@ -95,48 +91,47 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 					z-index: 0;
 				}
 
-				:host([dir="rtl"]) .assessment-label-skeleton {
-					margin-left: 0rem;
-					margin-right: 1.5rem;
-					float: right;
-				}
-
-				:host([dir="rtl"]) .assessment-level-label {
-					float: right;
+				.skeleton {
+					display: flex;
+					align-items: center;
 				}
 
 				.cell-content-container:hover .assessment-level-label {
 					text-decoration: underline;
 				}
 
-				:host([dir="rtl"]) .override-indicator {
-					float: right;
+				.assessment-info-container {
+					display: flex;
+					align-items: center;
+					height: 100%;
 				}
 
-				.assessment-outdated-icon {
-					display: inline-block;
-					float: right;
-					padding-right: 0.3rem;
-					padding-top: 0.15rem;
-				}
-
-				:host([dir="rtl"]) .assessment-outdated-icon {
-					float: left;
-					padding-left: 0.3rem;
-					padding-right: 0;
-				}
-
-				.assessment-publish-status-icon {
-					display: inline-block;
-					float: right;
+				.assessment-info-container > div {
+					padding-left: 1.5rem;
 					padding-right: 0.45rem;
-					padding-top: 0.3rem;
+					width: 100%;
+					display: flex;
+					align-items: center;
+					justify-content: space-between;
 				}
 
-				:host([dir="rtl"]) .assessment-publish-status-icon {
-					float: left;
+				:host([dir="rtl"]) .assessment-info-container > div {
 					padding-left: 0.45rem;
-					padding-right: 0;
+					padding-right: 1.5rem;
+				}
+
+				.assessment-icon-container {
+					display: flex;
+					align-items: center;
+				}
+
+				.assessment-icon-container > div {
+					padding-left: 0.3rem;
+				}
+
+				:host([dir="rtl"]) .assessment-icon-container > div {
+					padding-right: 0.3rem;
+					padding-left: 0;
 				}
 			`,
 			super.styles
@@ -175,35 +170,27 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 			@keydown=${this._onKeyDown}
 			aria-label="${this._getAriaText(data)}"
 		>
-			<div id="assessment-fraction-container" aria-hidden="true">
-				<span
-					id="assessment-fraction"
-					title=${this._getTooltipText(data.totalAssessments, data.totalEvaluatedAssessments)}
-				>
-					${data.totalEvaluatedAssessments}/${data.totalAssessments}
-				</span>
-			</div>
-			<div class="assessment-label-container" aria-hidden="true">
-				<div class="assessment-level-label d2l-body-compact" title="${data.levelName}">
-					${data.levelName}
+			${this._renderAssessmentFraction(data)}
+			<div class="assessment-info-container" aria-hidden="true">
+				<div aria-hidden="true">
+					<div class="assessment-label-container" aria-hidden="true">
+						<div class="assessment-level-label d2l-body-compact" title="${data.levelName}">
+							${data.levelName}
+						</div>
+						${this._renderOverrideIndicator(data)}
+					</div>
+					<div class="assessment-icon-container">
+						${this._renderAssessmentOutdatedIcon(data)}
+						<div
+							class="assessment-publish-status-icon"
+							aria-hidden="true"
+							title="${data.published ? this.localize('published') : this.localize('notPublished')}"
+						>
+							${data.published ? html`<d2l-icon-visibility-show></d2l-icon-visibility-show>` : html`<d2l-icon-visibility-hide></d2l-icon-visibility-hide>`}
+						</div>
+					</div>
 				</div>
-				${data.isManualOverride ? html`
-					<span class="override-indicator" title="${this.localize('manualOverride')}"><b>*</b></span>
-				` : null}
 			</div>
-			<div
-				class="assessment-publish-status-icon"
-				aria-hidden="true"
-				title="${data.published ? this.localize('published') : this.localize('notPublished')}"
-			>
-				${data.published ? html`<d2l-icon-visibility-show></d2l-icon-visibility-show>` : html`<d2l-icon-visibility-hide></d2l-icon-visibility-hide>`}
-			</div>
-			${data.outdated ? html`
-				<span aria-hidden="true" title="${this.localize('outOfDate')}">
-					<d2l-icon class="assessment-outdated-icon" icon="tier1:refresh"></d2l-icon>
-				</span>
-			` : null}
-
 		</div>
 		`;
 	}
@@ -339,6 +326,47 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 		if (event.keyCode === KEYCODES.ENTER || event.keyCode === KEYCODES.SPACE) {
 			this._onClick();
 		}
+	}
+
+	_renderAssessmentFraction(data) {
+		if (!data || !data.totalAssessments && !data.totalEvaluatedAssessments) {
+			return;
+		}
+
+		return html`
+			<div id="assessment-fraction-container" aria-hidden="true">
+				<span
+					id="assessment-fraction"
+					title=${this._getTooltipText(data.totalAssessments, data.totalEvaluatedAssessments)}
+				>
+					${data.totalEvaluatedAssessments}/${data.totalAssessments}
+				</span>
+			</div>
+		`;
+	}
+
+	_renderAssessmentOutdatedIcon(data) {
+		if (!data || !data.outdated) {
+			return;
+		}
+
+		return html`
+			<div aria-hidden="true" title="${this.localize('outOfDate')}">
+				<d2l-icon class="assessment-outdated-icon" icon="tier1:refresh"></d2l-icon>
+			</div>
+		`;
+	}
+
+	_renderOverrideIndicator(data) {
+		if (!data || !data.isManualOverride) {
+			return;
+		}
+
+		return html`
+			<span class="override-indicator" title="${this.localize('manualOverride')}">
+				<b>*</b>
+			</span>
+		`;
 	}
 
 }

--- a/src/mastery-view-table/mastery-view-user-outcome-cell.js
+++ b/src/mastery-view-table/mastery-view-user-outcome-cell.js
@@ -329,7 +329,7 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 	}
 
 	_renderAssessmentFraction(data) {
-		if (!data || !data.totalAssessments && !data.totalEvaluatedAssessments) {
+		if (!data || !Number.isInteger(data.totalAssessments) || !Number.isInteger(data.totalEvaluatedAssessments)) {
 			return;
 		}
 


### PR DESCRIPTION
This allows the removal of the ratio in the top left as well as not displaying the outdated icon. Layout and CSS were adjust to allow for the complete removal of the ratio without disrupting the layout as well as fixing some vertical
alignment issues. Also fixed up some issues with demo data.

**Ratio Hidden:**
![image](https://user-images.githubusercontent.com/9043211/117152442-04a4d180-ad88-11eb-9308-a10a8fb50456.png)

**Before:**
![before](https://user-images.githubusercontent.com/9043211/117152313-e6d76c80-ad87-11eb-9d78-92af50a3eabc.PNG)

**After:**
![after](https://user-images.githubusercontent.com/9043211/117152317-e8a13000-ad87-11eb-9bee-bb74ef7efe15.PNG)

Tested in **Chrome**, **Firefox** and **Edge** using dev BSI and demo pages.
Back-end changes are https://github.com/Brightspace/lms/pull/10182. Hotfix back-end changes are https://github.com/Brightspace/lms/pull/10217.