### PR TITLE
US127641 - Mastery View Histogram (Alternate Route)

### DIFF
--- a/demo/data/mastery-view-table/class-overall-achievement/0learners.json
+++ b/demo/data/mastery-view-table/class-overall-achievement/0learners.json
@@ -26,6 +26,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac-nostudents.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac-nostudents.json"
         }
       ]
     },
@@ -49,6 +55,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac-nostudents.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac-nostudents.json"
         }
       ]
     },
@@ -72,6 +84,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac-nostudents.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac-nostudents.json"
         }
       ]
     },
@@ -95,6 +113,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac-nostudents.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac-nostudents.json"
         }
       ]
     },
@@ -118,6 +142,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac-nostudents.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac-nostudents.json"
         }
       ]
     },
@@ -141,6 +171,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac-nostudents.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac-nostudents.json"
         }
       ]
     },
@@ -164,6 +200,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac-nostudents.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac-nostudents.json"
         }
       ]
     },
@@ -187,6 +229,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac-nostudents.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac-nostudents.json"
         }
       ]
     }

--- a/demo/data/mastery-view-table/class-overall-achievement/1learner.json
+++ b/demo/data/mastery-view-table/class-overall-achievement/1learner.json
@@ -26,6 +26,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac-full.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac-full.json"
         }
       ]
     },
@@ -49,6 +55,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac-partial.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac-partial.json"
         }
       ]
     },
@@ -72,6 +84,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac-noneassessed.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac-noneassessed.json"
         }
       ]
     },
@@ -95,6 +113,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac0.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac0.json"
         }
       ]
     },
@@ -118,6 +142,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac1.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac1.json"
         }
       ]
     },
@@ -141,6 +171,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac2.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac2.json"
         }
       ]
     },
@@ -164,6 +200,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac3.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac3.json"
         }
       ]
     },
@@ -187,6 +229,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac4.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac4.json"
         }
       ]
     }

--- a/demo/data/mastery-view-table/class-overall-achievement/200learners.json
+++ b/demo/data/mastery-view-table/class-overall-achievement/200learners.json
@@ -26,6 +26,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac-full_200learners.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-activity-collections/class/oac-full_200learners-level-distribution.json"
         }
       ]
     },
@@ -49,6 +55,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac-partial_200learners.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-activity-collections/class/oac-partial_200learners-level-distribution.json"
         }
       ]
     },
@@ -72,6 +84,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac-noneassessed_200learners.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-activity-collections/class/oac-noneassessed_200learners-level-distribution.json"
         }
       ]
     },
@@ -95,6 +113,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac0_200learners.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-activity-collections/class/oac0_200learners-level-distribution.json"
         }
       ]
     },
@@ -118,6 +142,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac1_200learners.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-activity-collections/class/oac1_200learners-level-distribution.json"
         }
       ]
     },
@@ -141,6 +171,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac2_200learners.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-activity-collections/class/oac2_200learners-level-distribution.json"
         }
       ]
     },
@@ -164,6 +200,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac3_200learners.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-activity-collections/class/oac3_200learners-level-distribution.json"
         }
       ]
     },
@@ -187,6 +229,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac4_200learners.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-activity-collections/class/oac4_200learners-level-distribution.json"
         }
       ]
     }

--- a/demo/data/mastery-view-table/class-overall-achievement/7learners.json
+++ b/demo/data/mastery-view-table/class-overall-achievement/7learners.json
@@ -26,6 +26,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac-full.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac-full.json"
         }
       ]
     },
@@ -49,6 +55,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac-partial.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac-partial.json"
         }
       ]
     },
@@ -72,6 +84,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac-noneassessed.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac-noneassessed.json"
         }
       ]
     },
@@ -95,6 +113,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac0.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac0.json"
         }
       ]
     },
@@ -118,6 +142,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac1.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac1.json"
         }
       ]
     },
@@ -141,6 +171,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac2.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac2.json"
         }
       ]
     },
@@ -164,6 +200,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac3.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac3.json"
         }
       ]
     },
@@ -187,6 +229,12 @@
             "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress"
           ],
           "href": "data/mastery-view-table/outcome-activity-collections/class/oac4.json"
+        },
+        {
+          "rel": [
+            "https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution"
+          ],
+          "href": "data/mastery-view-table/outcome-level-distributions/oac4.json"
         }
       ]
     }

--- a/demo/data/mastery-view-table/outcome-activity-collections/class/oac-full.json
+++ b/demo/data/mastery-view-table/outcome-activity-collections/class/oac-full.json
@@ -1,7 +1,7 @@
 {
   "class": [
     "collection",
-    "user-progress-outcome-activities"
+    "class-progress-checkpoint-item-activities"
   ],
   "entities": [
     {

--- a/demo/data/mastery-view-table/outcome-activity-collections/class/oac-full_200learners.json
+++ b/demo/data/mastery-view-table/outcome-activity-collections/class/oac-full_200learners.json
@@ -1,7 +1,7 @@
 {
   "class": [
     "collection",
-    "user-progress-outcome-activities"
+    "class-progress-checkpoint-item-activities"
   ],
   "entities": [
     {

--- a/demo/data/mastery-view-table/outcome-activity-collections/class/oac-noneassessed.json
+++ b/demo/data/mastery-view-table/outcome-activity-collections/class/oac-noneassessed.json
@@ -1,7 +1,7 @@
 {
   "class": [
     "collection",
-    "user-progress-outcome-activities"
+    "class-progress-checkpoint-item-activities"
   ],
   "entities": [
     {

--- a/demo/data/mastery-view-table/outcome-activity-collections/class/oac-noneassessed_200learners.json
+++ b/demo/data/mastery-view-table/outcome-activity-collections/class/oac-noneassessed_200learners.json
@@ -1,7 +1,7 @@
 {
   "class": [
     "collection",
-    "user-progress-outcome-activities"
+    "class-progress-checkpoint-item-activities"
   ],
   "entities": [
     {

--- a/demo/data/mastery-view-table/outcome-activity-collections/class/oac-nostudents.json
+++ b/demo/data/mastery-view-table/outcome-activity-collections/class/oac-nostudents.json
@@ -1,7 +1,7 @@
 {
   "class": [
     "collection",
-    "user-progress-outcome-activities"
+    "class-progress-checkpoint-item-activities"
   ],
   "links": [
     {

--- a/demo/data/mastery-view-table/outcome-activity-collections/class/oac-partial.json
+++ b/demo/data/mastery-view-table/outcome-activity-collections/class/oac-partial.json
@@ -1,7 +1,7 @@
 {
   "class": [
     "collection",
-    "user-progress-outcome-activities"
+    "class-progress-checkpoint-item-activities"
   ],
   "entities": [
     {

--- a/demo/data/mastery-view-table/outcome-activity-collections/class/oac-partial_200learners.json
+++ b/demo/data/mastery-view-table/outcome-activity-collections/class/oac-partial_200learners.json
@@ -1,7 +1,7 @@
 {
   "class": [
     "collection",
-    "user-progress-outcome-activities"
+    "class-progress-checkpoint-item-activities"
   ],
   "entities": [
     {

--- a/demo/data/mastery-view-table/outcome-activity-collections/class/oac0.json
+++ b/demo/data/mastery-view-table/outcome-activity-collections/class/oac0.json
@@ -1,7 +1,7 @@
 {
   "class": [
     "collection",
-    "user-progress-outcome-activities"
+    "class-progress-checkpoint-item-activities"
   ],
   "entities": [
     {

--- a/demo/data/mastery-view-table/outcome-activity-collections/class/oac0_200learners.json
+++ b/demo/data/mastery-view-table/outcome-activity-collections/class/oac0_200learners.json
@@ -1,7 +1,7 @@
 {
   "class": [
     "collection",
-    "user-progress-outcome-activities"
+    "class-progress-checkpoint-item-activities"
   ],
   "entities": [
     {

--- a/demo/data/mastery-view-table/outcome-activity-collections/class/oac1.json
+++ b/demo/data/mastery-view-table/outcome-activity-collections/class/oac1.json
@@ -1,7 +1,7 @@
 {
   "class": [
     "collection",
-    "user-progress-outcome-activities"
+    "class-progress-checkpoint-item-activities"
   ],
   "entities": [
     {

--- a/demo/data/mastery-view-table/outcome-activity-collections/class/oac1_200learners.json
+++ b/demo/data/mastery-view-table/outcome-activity-collections/class/oac1_200learners.json
@@ -1,7 +1,7 @@
 {
   "class": [
     "collection",
-    "user-progress-outcome-activities"
+    "class-progress-checkpoint-item-activities"
   ],
   "entities": [
     {

--- a/demo/data/mastery-view-table/outcome-activity-collections/class/oac2.json
+++ b/demo/data/mastery-view-table/outcome-activity-collections/class/oac2.json
@@ -1,7 +1,7 @@
 {
   "class": [
     "collection",
-    "user-progress-outcome-activities"
+    "class-progress-checkpoint-item-activities"
   ],
   "entities": [
     {

--- a/demo/data/mastery-view-table/outcome-activity-collections/class/oac2_200learners.json
+++ b/demo/data/mastery-view-table/outcome-activity-collections/class/oac2_200learners.json
@@ -1,7 +1,7 @@
 {
   "class": [
     "collection",
-    "user-progress-outcome-activities"
+    "class-progress-checkpoint-item-activities"
   ],
   "entities": [
     {

--- a/demo/data/mastery-view-table/outcome-activity-collections/class/oac3.json
+++ b/demo/data/mastery-view-table/outcome-activity-collections/class/oac3.json
@@ -1,7 +1,7 @@
 {
   "class": [
     "collection",
-    "user-progress-outcome-activities"
+    "class-progress-checkpoint-item-activities"
   ],
   "entities": [
     {

--- a/demo/data/mastery-view-table/outcome-activity-collections/class/oac3_200learners.json
+++ b/demo/data/mastery-view-table/outcome-activity-collections/class/oac3_200learners.json
@@ -1,7 +1,7 @@
 {
   "class": [
     "collection",
-    "user-progress-outcome-activities"
+    "class-progress-checkpoint-item-activities"
   ],
   "entities": [
     {

--- a/demo/data/mastery-view-table/outcome-activity-collections/class/oac4.json
+++ b/demo/data/mastery-view-table/outcome-activity-collections/class/oac4.json
@@ -1,7 +1,7 @@
 {
   "class": [
     "collection",
-    "user-progress-outcome-activities"
+    "class-progress-checkpoint-item-activities"
   ],
   "entities": [
     {

--- a/demo/data/mastery-view-table/outcome-activity-collections/class/oac4_200learners.json
+++ b/demo/data/mastery-view-table/outcome-activity-collections/class/oac4_200learners.json
@@ -1,7 +1,7 @@
 {
   "class": [
     "collection",
-    "user-progress-outcome-activities"
+    "class-progress-checkpoint-item-activities"
   ],
   "entities": [
     {

--- a/demo/data/mastery-view-table/outcome-level-distributions/oac-full.json
+++ b/demo/data/mastery-view-table/outcome-level-distributions/oac-full.json
@@ -11,8 +11,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level0",
-        "Count": 5
+        "levelId": "level0",
+        "count": 5
       }
     },
     {
@@ -23,8 +23,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level1",
-        "Count": 5
+        "levelId": "level1",
+        "count": 5
       }
     },
     {
@@ -35,8 +35,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level2",
-        "Count": 5
+        "levelId": "level2",
+        "count": 5
       }
     },
     {
@@ -47,8 +47,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": null,
-        "Count": 15
+        "levelId": null,
+        "count": 15
       }
     }
   ],

--- a/demo/data/mastery-view-table/outcome-level-distributions/oac-full.json
+++ b/demo/data/mastery-view-table/outcome-level-distributions/oac-full.json
@@ -1,0 +1,69 @@
+{
+  "class": [
+    "class-progress-loa-level-distribution"
+  ],
+  "entities": [
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level0",
+        "Count": 5
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level1",
+        "Count": 5
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level2",
+        "Count": 5
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": null,
+        "Count": 15
+      }
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "data/mastery-view-table/outcome-level-distributions/oac-full.json"
+    },
+    {
+      "rel": [
+        "default-achievement-scale"
+      ],
+      "href": "data/loa/scale0.json"
+    }
+  ]
+}

--- a/demo/data/mastery-view-table/outcome-level-distributions/oac-noneassessed.json
+++ b/demo/data/mastery-view-table/outcome-level-distributions/oac-noneassessed.json
@@ -1,0 +1,33 @@
+{
+  "class": [
+    "class-progress-loa-level-distribution"
+  ],
+  "entities": [
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": null,
+        "Count": 30
+      }
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "data/mastery-view-table/outcome-level-distributions/oac-noneassessed.json"
+    },
+    {
+      "rel": [
+        "default-achievement-scale"
+      ],
+      "href": "data/loa/scale0.json"
+    }
+  ]
+}

--- a/demo/data/mastery-view-table/outcome-level-distributions/oac-noneassessed.json
+++ b/demo/data/mastery-view-table/outcome-level-distributions/oac-noneassessed.json
@@ -11,8 +11,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": null,
-        "Count": 30
+        "levelId": null,
+        "count": 30
       }
     }
   ],

--- a/demo/data/mastery-view-table/outcome-level-distributions/oac-partial.json
+++ b/demo/data/mastery-view-table/outcome-level-distributions/oac-partial.json
@@ -1,0 +1,57 @@
+{
+  "class": [
+    "class-progress-loa-level-distribution"
+  ],
+  "entities": [
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level0",
+        "Count": 5
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level1",
+        "Count": 10
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": null,
+        "Count": 15
+      }
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "data/mastery-view-table/outcome-level-distributions/oac-partial.json"
+    },
+    {
+      "rel": [
+        "default-achievement-scale"
+      ],
+      "href": "data/loa/scale0.json"
+    }
+  ]
+}

--- a/demo/data/mastery-view-table/outcome-level-distributions/oac-partial.json
+++ b/demo/data/mastery-view-table/outcome-level-distributions/oac-partial.json
@@ -11,8 +11,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level0",
-        "Count": 5
+        "levelId": "level0",
+        "count": 5
       }
     },
     {
@@ -23,8 +23,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level1",
-        "Count": 10
+        "levelId": "level1",
+        "count": 10
       }
     },
     {
@@ -35,8 +35,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": null,
-        "Count": 15
+        "levelId": null,
+        "count": 15
       }
     }
   ],

--- a/demo/data/mastery-view-table/outcome-level-distributions/oac0.json
+++ b/demo/data/mastery-view-table/outcome-level-distributions/oac0.json
@@ -1,0 +1,69 @@
+{
+  "class": [
+    "class-progress-loa-level-distribution"
+  ],
+  "entities": [
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level0",
+        "Count": 10
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level1",
+        "Count": 10
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level2",
+        "Count": 5
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": null,
+        "Count": 5
+      }
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "data/mastery-view-table/outcome-level-distributions/oac0.json"
+    },
+    {
+      "rel": [
+        "default-achievement-scale"
+      ],
+      "href": "data/loa/scale0.json"
+    }
+  ]
+}

--- a/demo/data/mastery-view-table/outcome-level-distributions/oac0.json
+++ b/demo/data/mastery-view-table/outcome-level-distributions/oac0.json
@@ -11,8 +11,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level0",
-        "Count": 10
+        "levelId": "level0",
+        "count": 10
       }
     },
     {
@@ -23,8 +23,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level1",
-        "Count": 10
+        "levelId": "level1",
+        "count": 10
       }
     },
     {
@@ -35,8 +35,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level2",
-        "Count": 5
+        "levelId": "level2",
+        "count": 5
       }
     },
     {
@@ -47,8 +47,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": null,
-        "Count": 5
+        "levelId": null,
+        "count": 5
       }
     }
   ],

--- a/demo/data/mastery-view-table/outcome-level-distributions/oac1.json
+++ b/demo/data/mastery-view-table/outcome-level-distributions/oac1.json
@@ -1,0 +1,69 @@
+{
+  "class": [
+    "class-progress-loa-level-distribution"
+  ],
+  "entities": [
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level0",
+        "Count": 10
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level1",
+        "Count": 10
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level2",
+        "Count": 10
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": null,
+        "Count": 0
+      }
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "data/mastery-view-table/outcome-level-distributions/oac1.json"
+    },
+    {
+      "rel": [
+        "default-achievement-scale"
+      ],
+      "href": "data/loa/scale0.json"
+    }
+  ]
+}

--- a/demo/data/mastery-view-table/outcome-level-distributions/oac1.json
+++ b/demo/data/mastery-view-table/outcome-level-distributions/oac1.json
@@ -11,8 +11,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level0",
-        "Count": 10
+        "levelId": "level0",
+        "count": 10
       }
     },
     {
@@ -23,8 +23,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level1",
-        "Count": 10
+        "levelId": "level1",
+        "count": 10
       }
     },
     {
@@ -35,8 +35,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level2",
-        "Count": 10
+        "levelId": "level2",
+        "count": 10
       }
     },
     {
@@ -47,8 +47,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": null,
-        "Count": 0
+        "levelId": null,
+        "count": 0
       }
     }
   ],

--- a/demo/data/mastery-view-table/outcome-level-distributions/oac2.json
+++ b/demo/data/mastery-view-table/outcome-level-distributions/oac2.json
@@ -1,0 +1,69 @@
+{
+  "class": [
+    "class-progress-loa-level-distribution"
+  ],
+  "entities": [
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level0",
+        "Count": 10
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level1",
+        "Count": 2
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level2",
+        "Count": 17
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": null,
+        "Count": 1
+      }
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "data/mastery-view-table/outcome-level-distributions/oac2.json"
+    },
+    {
+      "rel": [
+        "default-achievement-scale"
+      ],
+      "href": "data/loa/scale0.json"
+    }
+  ]
+}

--- a/demo/data/mastery-view-table/outcome-level-distributions/oac2.json
+++ b/demo/data/mastery-view-table/outcome-level-distributions/oac2.json
@@ -11,8 +11,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level0",
-        "Count": 10
+        "levelId": "level0",
+        "count": 10
       }
     },
     {
@@ -23,8 +23,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level1",
-        "Count": 2
+        "levelId": "level1",
+        "count": 2
       }
     },
     {
@@ -35,8 +35,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level2",
-        "Count": 17
+        "levelId": "level2",
+        "count": 17
       }
     },
     {
@@ -47,8 +47,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": null,
-        "Count": 1
+        "levelId": null,
+        "count": 1
       }
     }
   ],

--- a/demo/data/mastery-view-table/outcome-level-distributions/oac3.json
+++ b/demo/data/mastery-view-table/outcome-level-distributions/oac3.json
@@ -1,0 +1,69 @@
+{
+  "class": [
+    "class-progress-loa-level-distribution"
+  ],
+  "entities": [
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level0",
+        "Count": 3
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level1",
+        "Count": 1
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level2",
+        "Count": 1
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": null,
+        "Count": 25
+      }
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "data/mastery-view-table/outcome-level-distributions/oac3.json"
+    },
+    {
+      "rel": [
+        "default-achievement-scale"
+      ],
+      "href": "data/loa/scale0.json"
+    }
+  ]
+}

--- a/demo/data/mastery-view-table/outcome-level-distributions/oac3.json
+++ b/demo/data/mastery-view-table/outcome-level-distributions/oac3.json
@@ -11,8 +11,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level0",
-        "Count": 3
+        "levelId": "level0",
+        "count": 3
       }
     },
     {
@@ -23,8 +23,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level1",
-        "Count": 1
+        "levelId": "level1",
+        "count": 1
       }
     },
     {
@@ -35,8 +35,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level2",
-        "Count": 1
+        "levelId": "level2",
+        "count": 1
       }
     },
     {
@@ -47,8 +47,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": null,
-        "Count": 25
+        "levelId": null,
+        "count": 25
       }
     }
   ],

--- a/demo/data/mastery-view-table/outcome-level-distributions/oac4.json
+++ b/demo/data/mastery-view-table/outcome-level-distributions/oac4.json
@@ -1,0 +1,69 @@
+{
+  "class": [
+    "class-progress-loa-level-distribution"
+  ],
+  "entities": [
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level0",
+        "Count": 20
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level1",
+        "Count": 8
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": "level2",
+        "Count": 1
+      }
+    },
+    {
+      "class": [
+        "class-progress-loa-level-count"
+      ],
+      "rel": [
+        "item"
+      ],
+      "properties": {
+        "LevelId": null,
+        "Count": 1
+      }
+    }
+  ],
+  "links": [
+    {
+      "rel": [
+        "self"
+      ],
+      "href": "data/mastery-view-table/outcome-level-distributions/oac4.json"
+    },
+    {
+      "rel": [
+        "default-achievement-scale"
+      ],
+      "href": "data/loa/scale0.json"
+    }
+  ]
+}

--- a/demo/data/mastery-view-table/outcome-level-distributions/oac4.json
+++ b/demo/data/mastery-view-table/outcome-level-distributions/oac4.json
@@ -11,8 +11,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level0",
-        "Count": 20
+        "levelId": "level0",
+        "count": 20
       }
     },
     {
@@ -23,8 +23,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level1",
-        "Count": 8
+        "levelId": "level1",
+        "count": 8
       }
     },
     {
@@ -35,8 +35,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": "level2",
-        "Count": 1
+        "levelId": "level2",
+        "count": 1
       }
     },
     {
@@ -47,8 +47,8 @@
         "item"
       ],
       "properties": {
-        "LevelId": null,
-        "Count": 1
+        "levelId": null,
+        "count": 1
       }
     }
   ],

--- a/demo/mastery-view-outcome-header-cell.html
+++ b/demo/mastery-view-outcome-header-cell.html
@@ -35,6 +35,20 @@
 				></d2l-mastery-view-outcome-header-cell>
 			</div>
 		</d2l-demo-snippet>
+
+		<h3>3 levels (Alternate Back-End Call)</h3>
+		<d2l-demo-snippet>
+			<div class="table-cell">
+				<d2l-mastery-view-outcome-header-cell
+					href="data/mastery-view-table/outcome-level-distributions/oac-full.json"
+					token="abc123"
+					outcome-name="D2L.MBU.0"
+					outcome-description="Students will demonstrate a clearer understanding of the career exploration process and how their own skills and interests match up to a chosen major/career path"
+					use-alternate-graph-call
+				></d2l-mastery-view-outcome-header-cell>
+			</div>
+		</d2l-demo-snippet>
+
 		<h3>3 levels with unassessed items</h3>
 		<d2l-demo-snippet>
 			<div class="table-cell">

--- a/demo/mastery-view-outcome-header-cell.html
+++ b/demo/mastery-view-outcome-header-cell.html
@@ -32,7 +32,6 @@
 					token="abc123"
 					outcome-name="D2L.MBU.0"
 					outcome-description="Students will demonstrate a clearer understanding of the career exploration process and how their own skills and interests match up to a chosen major/career path"
-					display-unassessed
 				></d2l-mastery-view-outcome-header-cell>
 			</div>
 		</d2l-demo-snippet>
@@ -44,7 +43,6 @@
 					token="abc123"
 					outcome-name="D2L.MBU.1"
 					outcome-description="Own the product - Familiar with the product line and know the persona of who the product is primarily built"
-					display-unassessed
 				></d2l-mastery-view-outcome-header-cell>
 			</div>
 		</d2l-demo-snippet>
@@ -57,7 +55,6 @@
 					token="abc123"
 					outcome-name="D2L.MBU.2"
 					outcome-description="Know the partnerships involved in the development of the product"
-					display-unassessed
 				></d2l-mastery-view-outcome-header-cell>
 			</div>
 		</d2l-demo-snippet>
@@ -69,7 +66,6 @@
 					token="abc123"
 					outcome-name="D2L.MBU.2"
 					outcome-description="Know the partnerships involved in the development of the product"
-					display-unassessed
 				></d2l-mastery-view-outcome-header-cell>
 			</div>
 		</d2l-demo-snippet>
@@ -81,7 +77,6 @@
 					token="abc123"
 					outcome-name="D2L.MBU.2"
 					outcome-description="Know the partnerships involved in the development of the product"
-					display-unassessed
 					disable-graph
 				></d2l-mastery-view-outcome-header-cell>
 			</div>

--- a/demo/mastery-view-table.html
+++ b/demo/mastery-view-table.html
@@ -32,6 +32,13 @@
 				token="abc123"
 			></d2l-mastery-view-table>
 
+			<h3>7 learners (Alternate Back-End Call)</h3>
+			<d2l-mastery-view-table
+				href="data/mastery-view-table/class-overall-achievement/7learners.json"
+				token="abc123"
+				use-alternate-graph-call
+			></d2l-mastery-view-table>
+
 			<h3>200 learners</h3>
 			<d2l-mastery-view-table
 				href="data/mastery-view-table/class-overall-achievement/200learners.json"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.62",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.1.62",
+  "version": "1.2.0",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "repository": "https://github.com/Brightspace/d2l-outcomes-overall-achievement.git",
   "scripts": {

--- a/src/entities/ClassOverallAchievementEntity.js
+++ b/src/entities/ClassOverallAchievementEntity.js
@@ -11,7 +11,8 @@ class OutcomeClassProgressEntity extends SelflessEntity {
 	static get links() {
 		return {
 			outcomeRel: 'https://outcomes.api.brightspace.com/rels/outcome',
-			outcomeActivityCollectionRel: 'https://user-progress.api.brightspace.com/rels/checkpoint-class-progress'
+			outcomeActivityCollectionRel: 'https://user-progress.api.brightspace.com/rels/checkpoint-class-progress',
+			outcomeLevelDistibutionRel: 'https://user-progress.api.brightspace.com/rels/checkpoint-class-progress-loa-level-distribution'
 		};
 	}
 
@@ -20,6 +21,13 @@ class OutcomeClassProgressEntity extends SelflessEntity {
 			return;
 		}
 		return this._entity.getLinkByRel(OutcomeClassProgressEntity.links.outcomeActivityCollectionRel).href;
+	}
+
+	getOutcomeLevelDistributionHref() {
+		if (!this._entity || !this._entity.hasLinkByRel(OutcomeClassProgressEntity.links.outcomeLevelDistibutionRel)) {
+			return;
+		}
+		return this._entity.getLinkByRel(OutcomeClassProgressEntity.links.outcomeLevelDistibutionRel).href;
 	}
 
 	onOutcomeChanged(onChange) {

--- a/src/entities/OutcomeLevelDistributionEntity.js
+++ b/src/entities/OutcomeLevelDistributionEntity.js
@@ -7,11 +7,11 @@ export class OutcomeLevelCountEntity extends SelflessEntity {
 	static get class() { return 'class-progress-loa-level-count'; }
 
 	getCount() {
-		return this._entity && this._entity.properties && this._entity.properties.Count;
+		return this._entity && this._entity.properties && this._entity.properties.count;
 	}
 
 	getLevelId() {
-		return this._entity && this._entity.properties && this._entity.properties.LevelId;
+		return this._entity && this._entity.properties && this._entity.properties.levelId;
 	}
 
 }

--- a/src/entities/OutcomeLevelDistributionEntity.js
+++ b/src/entities/OutcomeLevelDistributionEntity.js
@@ -1,0 +1,53 @@
+import { AchievementScaleEntity } from './AchievementScaleEntity';
+import { Entity } from 'siren-sdk/src/es6/Entity';
+import { SelflessEntity } from 'siren-sdk/src/es6/SelflessEntity';
+
+export class OutcomeLevelCountEntity extends SelflessEntity {
+
+	static get class() { return 'class-progress-loa-level-count'; }
+
+	getCount() {
+		return this._entity && this._entity.properties && this._entity.properties.Count;
+	}
+
+	getLevelId() {
+		return this._entity && this._entity.properties && this._entity.properties.LevelId;
+	}
+
+}
+
+export class OutcomeLevelDistributionEntity extends Entity {
+
+	static get class() { return 'class-progress-loa-level-distribution'; }
+
+	static get links() {
+		return {
+			defaultAchievementScale: 'default-achievement-scale'
+		};
+	}
+
+	getCounts() {
+		if (!this._entity) {
+			return;
+		}
+
+		const counts = this._entity.getSubEntitiesByClass(OutcomeLevelCountEntity.class);
+
+		return counts.map(count => new OutcomeLevelCountEntity(this, count));
+	}
+
+	onDefaultScaleChanged(onChange) {
+		const href = this._defaultScaleHref();
+
+		href && this._subEntity(AchievementScaleEntity, href, onChange);
+	}
+
+	_defaultScaleHref() {
+		if (!this._entity || !this._entity.hasLinkByRel(OutcomeLevelDistributionEntity.links.defaultAchievementScale)) {
+			return;
+		}
+
+		return this._entity.getLinkByRel(OutcomeLevelDistributionEntity.links.defaultAchievementScale).href;
+	}
+
+}

--- a/src/mastery-view-table/mastery-view-outcome-header-cell.js
+++ b/src/mastery-view-table/mastery-view-outcome-header-cell.js
@@ -290,11 +290,13 @@ export class MasteryViewOutcomeHeaderCell extends SkeletonMixin(LocalizeMixin(En
 			key => [key.getLevelId(), key.getCount()])
 		);
 
+		const histData = [];
+
 		for (const level of levels) {
 			const levelId = level.getLevelId();
 			const count = counts.get(levelId) || 0;
 
-			this._histData.push({
+			histData.push({
 				name: level.getName(),
 				color: level.getColor(),
 				count
@@ -304,11 +306,13 @@ export class MasteryViewOutcomeHeaderCell extends SkeletonMixin(LocalizeMixin(En
 
 		const count = counts.get(null) || 0;
 
-		this._histData.push({
+		histData.push({
 			name: this.localize('notEvaluated'),
 			color: Consts.unassessedColor,
 			count
 		});
+
+		this._histData = histData;
 		this._totalCount += count;
 	}
 

--- a/src/mastery-view-table/mastery-view-outcome-header-cell.js
+++ b/src/mastery-view-table/mastery-view-outcome-header-cell.js
@@ -34,7 +34,7 @@ export class MasteryViewOutcomeHeaderCell extends SkeletonMixin(LocalizeMixin(En
 			},
 			_histData: { attribute: false },
 			_assessedCount: { attribute: false },
-			_totalCount: { attribute: false },
+			_totalCount: { attribute: false }
 		};
 	}
 
@@ -267,11 +267,11 @@ export class MasteryViewOutcomeHeaderCell extends SkeletonMixin(LocalizeMixin(En
 	}
 
 	shouldUpdate(changedProperties) {
-		if (!this.disableGraph) {
-			return super.shouldUpdate(changedProperties);
+		if (this.disableGraph) {
+			return true;
 		}
 
-		return true;
+		return super.shouldUpdate(changedProperties);
 	}
 
 	set _entity(entity) {
@@ -353,8 +353,8 @@ export class MasteryViewOutcomeHeaderCell extends SkeletonMixin(LocalizeMixin(En
 	}
 
 	_getLevelCountText(levelData) {
-		const displayCount = this._totalCount;
-		const percentage = Math.floor(100.0 * levelData.count / (displayCount || 1));
+		const totalCount = this._totalCount || 1;
+		const percentage = Math.floor(100.0 * levelData.count / totalCount);
 
 		return this.localize('percentLabel', 'percentage', percentage);
 	}

--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -119,8 +119,12 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 				attribute: 'telemetry-endpoint'
 			},
 			disableGraph: {
-				attribute: 'disable-graph',
-				type: Boolean
+				type: Boolean,
+				attribute: 'disable-graph'
+			},
+			useAlternateGraphCall: {
+				type: Boolean,
+				attribute: 'use-alternate-graph-call'
 			},
 			_calculationMethod: { attribute: false },
 			_logger: { attribute: false },
@@ -311,6 +315,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 		this._setEntityType(ClassOverallAchievementEntity);
 
 		this.disableGraph = this.disableGraph || false;
+		this.useAlternateGraphCall = this.useAlternateGraphCall || false;
 		this._outcomeHeadersData = [];
 		this._learnerRowsData = [];
 		this._learnerList = [];
@@ -630,6 +635,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 		const outcomeClassProgressEntities = entity.getOutcomeClassProgressItems();
 		outcomeClassProgressEntities.map(outcomeProgressEntity => {
 			const activityCollectionHref = outcomeProgressEntity.getOutcomeActivityCollectionHref();
+			const outcomeLevelDistributionHref = outcomeProgressEntity.getOutcomeLevelDistributionHref();
 			outcomeProgressEntity.onOutcomeChanged(outcome => {
 				if (!outcome) {
 					return;
@@ -638,6 +644,7 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 				const outcomeData = {
 					href: outcome.getSelfHref(),
 					activityCollectionHref: activityCollectionHref,
+					outcomeLevelDistributionHref: outcomeLevelDistributionHref,
 					name: outcome.getNotation(),
 					description: outcome.getDescription(),
 					prefix: _getOutcomePrefix(outcome._entity.properties)
@@ -888,26 +895,34 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 	}
 
 	_renderOutcomeColumnHead(outcomeData, index) {
-		let tooltipAlign = 'center';
+		let tooltipAlign;
+
 		if (index === 0) {
 			tooltipAlign = 'start';
-		}
-		else if (index === this._outcomeHeadersData.length - 1) {
+		} else if (index === this._outcomeHeadersData.length - 1) {
 			tooltipAlign = 'end';
+		} else {
+			tooltipAlign = 'center';
 		}
 
+		const headerCellHref = this.useAlternateGraphCall ?
+			outcomeData.outcomeLevelDistributionHref :
+			outcomeData.activityCollectionHref;
+
 		return html`
-		<th scope="col" class="outcome-column-head" style="line-height: 1rem; padding: 0;">
-			<d2l-mastery-view-outcome-header-cell
-				href="${outcomeData.activityCollectionHref}"
-				token="${this.token}"
-				outcome-name="${ifDefined(outcomeData.name)}"
-				outcome-description="${ifDefined(outcomeData.description)}"
-				tooltip-align="${tooltipAlign}"
-				?disable-graph=${this.disableGraph}
-				aria-label="${this.localize('outcomeInfo', 'name', outcomeData.name, 'description', outcomeData.description)}"
-			></d2l-mastery-view-outcome-header-cell>
-		</th>`;
+			<th scope="col" class="outcome-column-head" style="line-height: 1rem; padding: 0;">
+				<d2l-mastery-view-outcome-header-cell
+					href="${headerCellHref}"
+					token="${this.token}"
+					outcome-name="${ifDefined(outcomeData.name)}"
+					outcome-description="${ifDefined(outcomeData.description)}"
+					tooltip-align="${tooltipAlign}"
+					?disable-graph=${this.disableGraph}
+					?use-alternate-graph-call=${this.useAlternateGraphCall}
+					aria-label="${this.localize('outcomeInfo', 'name', outcomeData.name, 'description', outcomeData.description)}"
+				></d2l-mastery-view-outcome-header-cell>
+			</th>
+		`;
 	}
 
 	_renderSearchMessage() {

--- a/src/mastery-view-table/mastery-view-table.js
+++ b/src/mastery-view-table/mastery-view-table.js
@@ -904,12 +904,10 @@ class MasteryViewTable extends EntityMixinLit(LocalizeMixin(TelemetryMixin(LitEl
 				outcome-name="${ifDefined(outcomeData.name)}"
 				outcome-description="${ifDefined(outcomeData.description)}"
 				tooltip-align="${tooltipAlign}"
-				display-unassessed
 				?disable-graph=${this.disableGraph}
 				aria-label="${this.localize('outcomeInfo', 'name', outcomeData.name, 'description', outcomeData.description)}"
 			></d2l-mastery-view-outcome-header-cell>
 		</th>`;
-
 	}
 
 	_renderSearchMessage() {

--- a/src/stacked-bar/stacked-bar.js
+++ b/src/stacked-bar/stacked-bar.js
@@ -11,22 +11,21 @@ export class StackedBar extends SkeletonMixin(LocalizeMixin(EntityMixinLit(LitEl
 
 	static get properties() {
 		return {
-			compact: { type: Boolean },
 			excludedTypes: {
 				attribute: 'excluded-types',
 				type: Array
+			},
+			compact: {
+				attribute: 'compact',
+				type: Boolean
 			},
 			displayUnassessed: {
 				attribute: 'display-unassessed',
 				type: Boolean
 			},
-			disableGraph: {
-				attribute: 'disable-graph',
-				type: Boolean
-			},
 			_histData: { attribute: false },
 			_assessedCount: { attribute: false },
-			_totalCount: { attribute: false },
+			_totalCount: { attribute: false }
 		};
 	}
 
@@ -151,7 +150,6 @@ export class StackedBar extends SkeletonMixin(LocalizeMixin(EntityMixinLit(LitEl
 
 	constructor() {
 		super();
-		this.disableGraph = this.disableGraph || false;
 		this.compact = this.compact || false;
 		this.excludedTypes = this.excludedTypes || [];
 		this._histData = [];
@@ -159,18 +157,12 @@ export class StackedBar extends SkeletonMixin(LocalizeMixin(EntityMixinLit(LitEl
 		this._assessedCount = 0;
 		this.skeleton = true;
 
-		if (!this.disableGraph) {
-			this._setEntityType(OutcomeActivityCollectionEntity);
-		}
+		this._setEntityType(OutcomeActivityCollectionEntity);
 	}
 
 	static get is() { return 'd2l-coa-stacked-bar'; }
 
 	render() {
-		if (this.disableGraph) {
-			return;
-		}
-
 		return html`
 			<div id="container" class="${this._getContainerClass(this.compact)}">
 				<div id="graph-container" tabindex="0" aria-labelledby="tooltip">
@@ -184,14 +176,6 @@ export class StackedBar extends SkeletonMixin(LocalizeMixin(EntityMixinLit(LitEl
 				</ul>
 			</div>
         `;
-	}
-
-	shouldUpdate(changedProperties) {
-		if (!this.disableGraph) {
-			return super.shouldUpdate(changedProperties);
-		}
-
-		return true;
 	}
 
 	set _entity(entity) {


### PR DESCRIPTION
Adjusts the UI to allow for the new alternate route for the histogram as well as it being feature flagged. [White-space diff off](https://github.com/Brightspace/d2l-outcomes-overall-achievement/pull/168/files?w=1).

Back-End: https://github.com/Brightspace/lms/pull/11283