### PR TITLE
Workaround for dependabot not having context/permission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,14 @@ jobs:
         run: npm ci
       - name: Test
         run: |
-          npm i karma-sauce-launcher@2 --no-save
-          npx karma start karma.sauce.conf.js
+          if ${{env.SAUCE_ACCESS_KEY != ''}}; then
+            echo "Running full test suite"
+            npm i karma-sauce-launcher@2 --no-save
+            npm run test:headless -- karma.sauce.conf.js
+          else
+            echo "Running minimal test suite"
+            npm run test:headless
+          fi
         env:
           SAUCE_USERNAME: Desire2Learn
           SAUCE_ACCESS_KEY: ${{secrets.SAUCE_ACCESS_KEY_DESIRE2LEARN}}


### PR DESCRIPTION
GitHub decided that dependabot PR's run with read only context and no access to secrets (they basically treat them as fork PR's). This means that sauce labs won't work and fails every time a PR is opened by dependabot. GitHub has provided no workaround for this change in permission that doesn't also cause large security issues for public repos. For now we can run the minimal headless tests which just run against chrome on the GitHub Action runner the tests are running on. If the context is available the full set of tests (any PR opened by a human will have this context). Note this can't be tested fully until the next dependabot PR is opened.