### PR TITLE
Fix: searching for students is producing unexpected results - DE42936

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "d2l-outcomes-overall-achievement",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A collection of components related to outcomes COA (Course Overall Achievement)",
   "repository": "https://github.com/Brightspace/d2l-outcomes-overall-achievement.git",
   "scripts": {

--- a/src/mastery-view-table/mastery-view-user-outcome-cell.js
+++ b/src/mastery-view-table/mastery-view-user-outcome-cell.js
@@ -7,7 +7,7 @@ import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/st
 import { Consts } from '../consts';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { ErrorLogger } from '../ErrorLogger.js';
-import { ifDefined } from 'lit/directives/if-defined.js';
+import { ifDefined } from 'lit-html/directives/if-defined';
 import { LocalizeMixin } from '../LocalizeMixin';
 import { MasteryViewRowEntity } from '../entities/MasteryViewRowEntity';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';

--- a/src/mastery-view-table/mastery-view-user-outcome-cell.js
+++ b/src/mastery-view-table/mastery-view-user-outcome-cell.js
@@ -7,6 +7,7 @@ import { bodyCompactStyles } from '@brightspace-ui/core/components/typography/st
 import { Consts } from '../consts';
 import { EntityMixinLit } from 'siren-sdk/src/mixin/entity-mixin-lit';
 import { ErrorLogger } from '../ErrorLogger.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { LocalizeMixin } from '../LocalizeMixin';
 import { MasteryViewRowEntity } from '../entities/MasteryViewRowEntity';
 import { SkeletonMixin } from '@brightspace-ui/core/components/skeleton/skeleton-mixin.js';
@@ -173,7 +174,7 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 			<div class="assessment-info-container" aria-hidden="true">
 				<div aria-hidden="true">
 					<div class="assessment-label-container" aria-hidden="true">
-						<div class="assessment-level-label d2l-body-compact" title="${data.levelName}">
+						<div class="assessment-level-label d2l-body-compact" title="${ifDefined(data.levelName)}">
 							${data.levelName}
 						</div>
 						${this._renderOverrideIndicator(data)}

--- a/src/mastery-view-table/mastery-view-user-outcome-cell.js
+++ b/src/mastery-view-table/mastery-view-user-outcome-cell.js
@@ -258,6 +258,8 @@ export class MasteryViewUserOutcomeCell extends SkeletonMixin(LocalizeMixin(Enti
 
 		const cellEntity = entity.getCells().find(cell => cell.getOutcomeHref() === this.outcomeHref);
 		if (!cellEntity) {
+			this._cellData = {};
+			this.skeleton = true;
 			return;
 		}
 


### PR DESCRIPTION
### The Problem

When searching for students in mastery view it is producing unexpected results for students with skeleton/undefined cell data states. See gif showing issue. Note the following:

- `user, Fname` has outcomes loaded in table, `user2, Fname` also has outcomes loaded but doesn't have any data to map to the table, `user3, Fname` doesn't have any outcomes loaded and is a skeleton/undefined state
- When searching for `user, Fname` the results are as expected/correct. 
- When searching for `user3` AFTER `user, Fname` it does not update to display the expected skeleton cells but instead shows `user, Fname` results. This is the issue we are trying to fix.
- When searching for `user2, Fname` AFTER `user, Fname` the results are expected/correct.

![no-search-issue-with-defined-outcomes](https://user-images.githubusercontent.com/64804046/124624516-eff9be00-de4a-11eb-8c94-ba9fd21d8d0c.gif)

### The Why
The reason that search results for `user3` are showing up incorrectly is because of state not being reset properly when calls don't return any data. Specifically on line [261](https://github.com/Brightspace/d2l-outcomes-overall-achievement/blob/master/src/mastery-view-table/mastery-view-user-outcome-cell.js#L261) when `cellEntity` is undefined and defaults to a `return` statement. This causes an issue since the previous search result set the `this._cellData` in the component to `user, Fname` and did not clear the existing information when `cellEntity` is `undefined` causing incorrect information to be displayed.

### The Fix
Clear `this._cellData` and set `this.skeleton` to `true` when `cellEntity` is `undefined`.

![fix-mastery-view-search-results](https://user-images.githubusercontent.com/64804046/124625551-e755b780-de4b-11eb-9ffe-97a55f4462f9.gif)

Rally ticket: https://rally1.rallydev.com/#/57732444928d/custom/373260458992?detail=%2Fdefect%2F513303680636


