### PR TITLE
Add automatic semantic release action - US129364

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+on:
+  push:
+    branches:
+      - master
+      - release/*
+      - '[0-9]+.x'
+      - '[0-9]+.[0-9]+.x'
+env:
+  NODE_VERSION: 14 # Latest LTS
+jobs:
+  release:
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
+    name: Release
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: Brightspace/third-party-actions@actions/checkout
+        with:
+          persist-credentials: false
+      - name: Setup node
+        uses: Brightspace/third-party-actions@actions/setup-node
+        with:
+          node-version: ${{env.NODE_VERSION}}
+      - name: Semantic Release
+        uses: BrightspaceUI/actions/semantic-release@master
+        with:
+          GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -260,13 +260,46 @@ npm run test:headless:watch
    - Google translate. This is in case auto-translations don't run in time, if
      we don't have french, we can get fined.
 
-### Versioning & Releasing
+## Versioning & Releasing
 
-Run `npm version --no-git-tag-version [major | minor | patch]` in project
-root directory, selecting the appropriate version increase type. This will bump
-the version in both `package.json` and `package-lock.json` and leave it in your
-working changes. Once checking this in and it being merged to `master` create
-a GitHub release matching the version in the `package.json`.
+> TL;DR: Commits prefixed with `fix:` and `feat:` will trigger patch and minor releases when merged to `master`. Read on for more details...
+The [sematic-release GitHub Action](https://github.com/BrightspaceUI/actions/tree/master/semantic-release) is called from the `release.yml` GitHub Action workflow to handle version changes and releasing.
+
+### Version Changes
+
+All version changes should obey [semantic versioning](https://semver.org/) rules:
+
+1. **MAJOR** version when you make incompatible API changes,
+2. **MINOR** version when you add functionality in a backwards compatible manner, and
+3. **PATCH** version when you make backwards compatible bug fixes.
+
+The next version number will be determined from the commit messages since the previous release. Our semantic-release configuration uses the [Angular convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular) when analyzing commits:
+
+- Commits which are prefixed with `fix:` or `perf:` will trigger a `patch` release. Example: `fix: validate input before using`
+- Commits which are prefixed with `feat:` will trigger a `minor` release. Example: `feat: add toggle() method`
+- To trigger a MAJOR release, include `BREAKING CHANGE:` with a space or two newlines in the footer of the commit message
+- Other suggested prefixes which will **NOT** trigger a release: `build:`, `ci:`, `docs:`, `style:`, `refactor:` and `test:`. Example: `docs: adding README for new component`
+
+To revert a change, add the `revert:` prefix to the original commit message. This will cause the reverted change to be omitted from the release notes. Example: `revert: fix: validate input before using`.
+
+### Releases
+
+When a release is triggered, it will:
+
+- Update the version in `package.json`
+- Tag the commit
+- Create a GitHub release (including release notes)
+
+### Releasing from Maintenance Branches
+
+Occasionally you'll want to backport a feature or bug fix to an older release. `semantic-release` refers to these as [maintenance branches](https://semantic-release.gitbook.io/semantic-release/usage/workflow-configuration#maintenance-branches).
+
+Maintenance branch names should be of the form: `+([0-9])?(.{+([0-9]),x}).x`.
+
+Regular expressions are complicated, but this essentially means branch names should look like:
+
+- `1.15.x` for patch releases on top of the `1.15` release (after version `1.16` exists)
+- `2.x` for feature releases on top of the `2` release (after version `3` exists)
 
 <!-- links -->
 [CI Badge]: https://github.com/Brightspace/d2l-outcomes-overall-achievement/workflows/CI/badge.svg?branch=master


### PR DESCRIPTION
Adding [semantic-release](https://github.com/BrightspaceUI/actions/tree/master/semantic-release) action to d2l-rubric repo.

Copied README additions from BSI README [here](https://github.com/BrightspaceUI/actions/tree/master/semantic-release). 

Rally ticket: https://rally1.rallydev.com/#/57732444928d/custom/373260458992?detail=%2Fuserstory%2F602326891667