### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Brightspace/mango


### PR DESCRIPTION
This adds the @Brightspace/mango group as code owners for all code in this repository. I'm only gonna add it to this repository for now as I want to see how it works out with the options for auto assigning reviewers.