### PR TITLE
chore(deps-dev): add `@babel/core` explicitly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,27 +20,241 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.1.tgz",
-      "integrity": "sha512-FzeKfFBG2rmFtGiiMdXZPFt/5R5DXubVi82uYhjGX4Msf+pgYQMCFIqFXZWs5vbIYbf14VeBIgdGI03CDOOM1w==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.6.tgz",
+      "integrity": "sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.0",
-        "@babel/helper-compilation-targets": "^7.13.0",
-        "@babel/helper-module-transforms": "^7.13.0",
-        "@babel/helpers": "^7.13.0",
-        "@babel/parser": "^7.13.0",
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0",
+        "@babel/code-frame": "^7.14.5",
+        "@babel/generator": "^7.14.5",
+        "@babel/helper-compilation-targets": "^7.14.5",
+        "@babel/helper-module-transforms": "^7.14.5",
+        "@babel/helpers": "^7.14.6",
+        "@babel/parser": "^7.14.6",
+        "@babel/template": "^7.14.5",
+        "@babel/traverse": "^7.14.5",
+        "@babel/types": "^7.14.5",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
-        "lodash": "^4.17.19",
-        "semver": "7.0.0",
+        "semver": "^6.3.0",
         "source-map": "^0.5.0"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "@babel/compat-data": {
+          "version": "7.14.7",
+          "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
+          "integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==",
+          "dev": true
+        },
+        "@babel/generator": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
+          "integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-compilation-targets": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
+          "integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
+          "dev": true,
+          "requires": {
+            "@babel/compat-data": "^7.14.5",
+            "@babel/helper-validator-option": "^7.14.5",
+            "browserslist": "^4.16.6",
+            "semver": "^6.3.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+          "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.14.5",
+            "@babel/template": "^7.14.5",
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+          "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+          "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.14.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
+          "integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-module-imports": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
+          "integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-module-transforms": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz",
+          "integrity": "sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-module-imports": "^7.14.5",
+            "@babel/helper-replace-supers": "^7.14.5",
+            "@babel/helper-simple-access": "^7.14.5",
+            "@babel/helper-split-export-declaration": "^7.14.5",
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "@babel/template": "^7.14.5",
+            "@babel/traverse": "^7.14.5",
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-optimise-call-expression": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
+          "integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
+          "integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.14.5",
+            "@babel/helper-optimise-call-expression": "^7.14.5",
+            "@babel/traverse": "^7.14.5",
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-simple-access": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz",
+          "integrity": "sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+          "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+          "dev": true
+        },
+        "@babel/helper-validator-option": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
+          "integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.14.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+          "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+          "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/parser": "^7.14.5",
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.14.7",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
+          "integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.14.5",
+            "@babel/helper-function-name": "^7.14.5",
+            "@babel/helper-hoist-variables": "^7.14.5",
+            "@babel/helper-split-export-declaration": "^7.14.5",
+            "@babel/parser": "^7.14.7",
+            "@babel/types": "^7.14.5",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+          "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "@babel/eslint-parser": {
@@ -321,14 +535,135 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.0.tgz",
-      "integrity": "sha512-aan1MeFPxFacZeSz6Ld7YZo5aPuqnKlD7+HZY75xQsueczFccP9A7V05+oe0XpLwHK3oLorPe9eaAUljL7WEaQ==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.6.tgz",
+      "integrity": "sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0"
+        "@babel/template": "^7.14.5",
+        "@babel/traverse": "^7.14.5",
+        "@babel/types": "^7.14.5"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
+          "integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.14.5"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.5.tgz",
+          "integrity": "sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-function-name": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
+          "integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-get-function-arity": "^7.14.5",
+            "@babel/template": "^7.14.5",
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-get-function-arity": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
+          "integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-hoist-variables": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
+          "integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-split-export-declaration": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
+          "integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz",
+          "integrity": "sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+          "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.14.7",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.7.tgz",
+          "integrity": "sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==",
+          "dev": true
+        },
+        "@babel/template": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
+          "integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/parser": "^7.14.5",
+            "@babel/types": "^7.14.5"
+          }
+        },
+        "@babel/traverse": {
+          "version": "7.14.7",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.7.tgz",
+          "integrity": "sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.14.5",
+            "@babel/helper-function-name": "^7.14.5",
+            "@babel/helper-hoist-variables": "^7.14.5",
+            "@babel/helper-split-export-declaration": "^7.14.5",
+            "@babel/parser": "^7.14.7",
+            "@babel/types": "^7.14.5",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.14.5",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.5.tgz",
+          "integrity": "sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.5",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/highlight": {
@@ -3737,9 +4072,9 @@
       "dev": true
     },
     "convert-source-map": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-      "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
+      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
       "dev": true,
       "requires": {
         "safe-buffer": "~5.1.1"

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "siren-sdk": "github:BrightspaceHypermediaComponents/siren-sdk#semver:^1"
   },
   "devDependencies": {
+    "@babel/core": "^7",
     "@babel/eslint-parser": "^7",
     "@open-wc/testing": "^2",
     "@open-wc/testing-karma": "^4",


### PR DESCRIPTION
This is a peer dependency of `@babel/eslint-parser`. This isn't installed by default in npm less than 7 as peer dependencies aren't installed by default so for now we should just add it explicitly to cover node 14.x cases since it is the latest LTS.